### PR TITLE
Fix broken link

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -11,4 +11,4 @@ The Cloud Native Computing Foundation seeks to drive adoption of this paradigm b
 
 ## Terms
 
-Moved terms into their own files. You can find them [here](/definitions)
+Moved terms into their own files. You can find them [here](/content/en)


### PR DESCRIPTION
Solves #241 - link was pointing to where the terms were originally stored. Maybe glossary.md isn't needed any more since the readme and website describe how to contribute.