### PR TITLE
Add Korean l10n for testing a new l10n

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,14 @@ weight = 1
 #time_format_default = "02.01.2006"
 #time_format_blog = "02.01.2006"
 
+[languages.ko]
+title = "클라우드 네이티브(Cloud Native) 용어집"
+description = "CNCF 클라우드 네이티브 용어집 프로젝트는 클라우드 네이티브 애플리케이션에 대한 대화를 나눌 때 공통의 용어를 참조하여 사용하도록 하는 목적을 가지고 있다."
+languageName ="한국어"
+contentDir = "content/ko"
+weight = 2
+
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/content/ko/_index.md
+++ b/content/ko/_index.md
@@ -1,0 +1,24 @@
+
+---
+title: "클라우드 네이티브 용어집"
+---
+
+# 클라우드 네이티브 용어집
+
+클라우드 네이티브 용어집(Cloud Native Glossary)은 CNCF 비지니스 벨류 서브커미티(BVS, Business Value Subcommittee)가 주도하는 프로젝트이다. 이 프로젝트의 목적은 사전 기술 지식이 없이도 명확하고 간단한 언어로 클라우드 네이티브 개념을 설명하는 것이다. [여기서 PDF 버전을 보거나 다운로드할 수 있음(영문)](https://github.com/cncf/glossary/blob/main/cloudnative-glossary.pdf).
+
+## 기여하기
+네이티브 용어집에 대한 변경, 추가 및 개선은 모든 사람에게 열려있다. 우리는 이 공유된 어휘(lexicon)를 개발 및 개선하기 위해서 CNCF가 관리하는 커뮤니티-주도 프로세스를 사용한다. 이 용어집은 클라우드 네이티브 기술들에 대한 공유 어휘를 관리하기 위해서 벤더-중립적 플랫폼을 제공한다. 본 프로젝트의 목적과 헌장(charter)을 준수하는 모든 참여자의 기여를 환영한다.
+
+기여를 하고 싶은 사람은 GitHub 이슈를 제출하거나 풀 리퀘스트(pull request)를 생성하면 된다.  더 자세한 정보는 [기여 방법](/ko/contribute/)을 확인하길 바라며 [스타일 가이드](/ko/style-guide/)를 준수하길 바란다.
+
+## 사사(acknowledgements)
+
+클라우드 네이티브 용어집은 CNCF 마케팅 커미티(CNCF Marketing
+Committee) (비지니스 벨류 서브커미티)를
+포함한 [Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), [Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/),
+[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk), [Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), [Katelin Ramer](https://www.linkedin.com/in/katelinramer/), [Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca) 기여자의 기여를 통해서 개시되었다.
+
+## 라이선스
+
+모든 코드 기여는 Apache 2.0 라이선스 하에 있다. 문서는 CC BY 4.0에 따라 배포된다.

--- a/content/ko/cloud_native_tech.md
+++ b/content/ko/cloud_native_tech.md
@@ -1,0 +1,17 @@
+---
+title: 클라우드 네이티브 기술
+status: Completed
+category: 개념
+---
+
+## What it is
+
+Cloud native technologies, also referred to as the cloud native stack, are the technologies used to build [cloud native applications](/cloud_native_apps/). Enabling organizations to build and run scalable applications in modern, dynamic environments such as public, private, and hybrid clouds, they uphold the ‘promise of the cloud’ and leverage cloud computing benefits to their fullest. They are designed from the ground up to exploit the capabilities of cloud computing and containers, service meshes, microservices, and immutable infrastructure exemplify this approach.
+
+## Problem it addresses 
+
+The cloud native stack has many different technology categories, addressing a variety of challenges. If you have a look at the [CNCF Cloud Native Landscape](https://landscape.cncf.io/), you'll see how many different areas it touches upon. But on a high level, they address one main set of challenges: the downsides of traditional IT operating models. Challenges include difficulties creating scalable, fault-tolerant, self-healing applications, as well as inefficient resource utilization, among others.
+
+## How it helps
+
+While each technology addresses a very specific problem, as a group, cloud native technologies enable loosely coupled systems that are resilient, manageable, and observable. Combined with robust automation, they allow engineers to make high-impact changes frequently and predictably with minimal toil. Desirable traits of cloud native systems are easier to achieve with the cloud native stack.

--- a/content/ko/contribute/_index.md
+++ b/content/ko/contribute/_index.md
@@ -1,0 +1,42 @@
+---
+title: 기여 방법
+toc_hide: true
+menu:
+  main:
+    weight: 10
+    pre: <i class='fas fa-pen-square'></i>
+---
+
+All the content for the Cloud Native Glossary is stored in [this GitHub repo](https://github.com/cncf/glossary).  You'll find there a list of [issues](https://github.com/cncf/glossary/issues), [PRs](https://github.com/cncf/glossary/pulls), and [discussions](https://github.com/cncf/glossary/discussions) about the glossary.
+
+## General guidelines
+To propose specific changes to a glossary entry, edit that entry in your branch and issue a pull request. To request that an entry be clarified, updated, or reconsidered, you may alternatively open an issue. To propose a new entry to the glossary, either create an issue or, if you have the definition drafted, add the entry to your branch and create a pull request.
+
+
+## Issues
+
+Please jump in and help us out by reviewing [open issues](https://github.com/cncf/glossary/issues) and making pull requests to resolve them.  The easiest ones have been marked with the “good first issue” or “help wanted” tags.  Choose one that hasn't already been assigned to someone:
+
+![issues](/images/how-to/3.png)
+
+Other that haven't yet been assigned may have been "claimed" by someone. Click on the issue to learn more about it. The example below is already claimed:
+
+![claims](/images/how-to/4.png)
+
+You can submit a new issue by clicking "Report issue" in the right sidebar of any page in the Glossary.
+
+## Updating a term (aka submitting a PR)
+Follow these steps to update a glossary entry:
+1. Navigate to the term you'd like to edit
+2. Click "Edit this page" link in the right sidebar
+3. Create your own fork of the repository
+3. Make your changes to the content
+5. Create a pull request
+
+Please title your pull requests appropriately, summing up what your commits are about. Also, please raise separate pull requests for each change as this makes it easier to discuss and shepherd updates in self-contained units.  Provide links to third-party uses that support your issue or pull request.  After successfully submitting your PR, you should see it here:
+
+![success](/images/how-to/5.png)
+
+If you run into problems please reach out on [Slack](https://slack.cncf.io/) in the #marketing-business-value channel. We'll be happy to help! 
+
+See the [Style Guide](/style-guide) for information on the format and style of glossary entries.

--- a/content/ko/style-guide/_index.md
+++ b/content/ko/style-guide/_index.md
@@ -1,0 +1,104 @@
+---
+title: 스타일 가이드
+toc_hide: true
+menu:
+  main:
+    weight: 10
+    pre: <i class='fas fa-ruler-horizontal'></i>
+---
+
+The following style guide is designed to help you understand the glossary definition structure and maintain a consistent style throughout.
+
+The Cloud Native Glossary follows the [default style guide](https://github.com/cncf/foundation/blob/master/style-guide.md) located in the CNCF's repository.  Additionally it follows the following rules:
+
+1. [Avoid colloquial language](https://en.wikipedia.org/wiki/Colloquialism)
+2. [Use literal and concrete language](http://guidetogrammar.org/grammar/composition/abstract.htm)
+3. [Omit contractions](https://en.wikipedia.org/wiki/Contraction_(grammar))
+4. [Use passive voice sparingly](https://www.ef.com/ca/english-resources/english-grammar/passive-voice/)
+5. [Aim to phrase statements in a positive form](https://examples.yourdictionary.com/positive-sentence-examples.html) 
+6. [No exclamation marks outside of quotations](https://www.grammarly.com/blog/exclamation-mark/)
+7. Do not exaggerate
+8. Avoid repetition
+9. Be concise
+
+## Definition Template
+
+Each glossary term is stored in a markdown file and follows this template:
+
+```md
+---
+title: 
+status: 
+category: 
+---
+
+## What it is
+
+A quick summary of the technology or concept.
+
+## Problem it addresses 
+
+A few lines about the problem it's addressing.
+
+## How it helps
+
+A few lines on how the thing solves the problem.
+```
+
+### Title
+
+The **title** label will always be at the top of a definition layout and its value should be in title case. 
+
+```md
+---
+title: Definition Template
+```
+
+### Status
+
+The **status** label will come after the title label. The status label indicates whether definitions are thoroughly vetted or require more effort.
+
+Valid values are: 
+
+- Completed
+- Feedback Appreciated 
+- Not Started
+
+You can always open an issue against a completed definition. While a definition is in flux, its status will be changed to *Feedback Appreciated*.
+
+```md
+---
+title: Definition Template
+status: Feedback Appreciated
+```
+
+### Category
+
+The **category** label will come after the status label. Its value should be one of the following values:
+
+- Technology
+- Property
+- Concept
+
+```md
+---
+title: Definition Template
+status: Feedback Appreciated
+category: Concept
+---
+```
+
+### Definition
+
+The definition contains three subheadings to give the readers context: "What it is", "Problem it addresses", and "How it helps". All three are required for terms in the Technology and Concept categories, however, Property definitions do not require these headings. 
+
+
+## Audience
+
+The glossary is for a technical AND non-technical audience. So please ensure definitions are explained in simple terms and don't assume technical knowledge. When appropriate, use real-world examples that help readers (especially non-technical readers) better understand when and why the concept you're explaining is relevant. Also, link directly to glossary terms when used in your definition (only the first mention should be hyperlinked) and make sure to run your text through a spell check program.
+
+As an example, take a look at the "What it is" section of the [service mesh definition](/service_mesh). It links back to the microservices, service, reliability, and observability definitions and uses a real-world example so (non-technical) readers can better relate to network challenges (comparing it to a wifi network everyone is familiar with).
+
+Before getting started, please read some of the published terms on this site so you get a feeling for the level of detail and difficulty as well as when examples are appropriate.
+
+The definition of a term should be based on empirical evidence of contemporary usage as published in literature, academic articles, talks, and white papers. In some cases, a term will suffer from conflation, imprecise usage, or, even worse, outright conflicting definitions. In these cases, the Glossary Committers will consider proposed clarifications or focused definitions on a case-by-case basis.


### PR DESCRIPTION
This PR is to test a new localization. 

As an example, I added Korean localization.

I think we can check netlify preview of this PR and discuss to enhance localization guideline and enhancement points for this site. (ref: #251)

To add a new localization, we need to include
 - `[languages.ko]` section in `config.toml`
 - content/**ko**/ directory
 - Translated document for Home (content/ko/_index.md)

I hope to note that
- this PR includes a document translated into Korean. (it is also an example)
- there is no Korean localization team yet. 
- I am aware of this PR will not be approved :) 
- https://gohugo.io/functions/lang.merge/ seems not working. 
  - If we don't include translated file, that file is not visible in sidebar-tree