### PR TITLE
Add content/pt/blue_green_deployment.md

### DIFF
--- a/content/pt/blue_green_deployment.md
+++ b/content/pt/blue_green_deployment.md
@@ -1,0 +1,18 @@
+---
+title: Blue Green Deployment
+status: Completed
+category: concept
+---
+
+## O que é
+
+O Blue-green deployment é uma estratégia para atualizar os sistemas de computador em execução com o mínimo de tempo de inatividade. O operador mantém dois ambientes, chamados "blue" e "green".
+Um atende ao tráfego de produção (a versão que os usuários estão usando atualmente), enquanto o outro é atualizado. Depois que o teste é concluído no ambiente inativo (green), o tráfego de produção é alternado (geralmente com o uso de um baleanceador de carga - load balancer). Observe que blue-green deployment geralmente significa alternar os ambientes por completo, abrangendo muitos serviços, todos de uma vez. Surpreendentemente, às vezes o termo é usado em relação a serviços individuais em um sistema. Para evitar essa ambiguidade, o termo "zero-downtime deployment" é preferido quando se refere a componentes individuais.
+
+## Qual problema é resolvido
+
+Blue-green deployments permitem tempo mínimo de inatividade ao atualizar o software que deve ser alterado em "lockstep" devido à falta de compatibilidade com versões anteriores. Por exemplo, blue-green deployment poderia ser apropriado para uma loja online consistindo de um site e um banco de dados que precisa ser atualizado, mas a nova versão do banco de dados não funciona com a versão antiga do site, e vice-versa. Neste caso, ambos precisam ser alterados ao mesmo tempo. Se isso fosse feito em um sistema de produção, os clientes perceberiam um tempo de inatividade.
+
+## No que isso ajuda
+
+Blue-green deployment é uma estratégia apropriada para softwares nativos que não são armazenados na nuvem e que precisam ser atualizados com o mínimo de tempo de inatividade. No entanto, o seu uso é normalmente um sinal ("code smell") de que o software legado precisa reprojetado de forma que os componentes possam ser atualizados individualmente.


### PR DESCRIPTION
Hi, 
As mentioned in https://github.com/cncf/glossary/issues/269, here is a second PR, but now trying to translate the Blue Green Deployment page - https://glossary.cncf.io/blue_green_deployment/

I've seen also that this is translated as `"implantação azul-verde"` - open to suggestions.. also for the name of the sections (see https://github.com/cncf/glossary/pull/273#discussion_r766942120)

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>