### PR TITLE
Bumped spellcheck action to latest version (0.19.0)

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -2,7 +2,7 @@
 
 name: Spellcheck CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   pull_request:
@@ -25,4 +25,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: GitHub Spellcheck Action
-        uses: rojopolis/spellcheck-github-actions@0.13.0
+        uses: rojopolis/spellcheck-github-actions@0.19.0


### PR DESCRIPTION
Hello,

I have just [released 0.19.0 of the GitHub Spellcheck Action](https://dev.to/jonasbn/releases-0190-of-spellcheck-github-action-a-security-release-599k) and I noticed that older versions of the Docker image had been pulled from DockerHub recently. 

I was able to locate your configuration via [SourceGraph](https://sourcegraph.com/github.com/cncf/glossary/-/blob/.github/workflows/spellcheck.yml), so I am providing you with a PR proposing an update to a more contemporary version.

It should be backwards compatible even though a lot has happened, but if you experience any issue with the PR please let me know and I will comply.

Take care and stay safe,

jonasbn