### PR TITLE
Remove emeritus maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,3 @@
 # We require at least two maintainers to sign off on a new term
 
 * @caniszczyk @CathPag @jasonmorgan 
-
-# Maintainers emeritus 
-* @IdealUsrname @DanielJonesEB


### PR DESCRIPTION
Introduced a bug where emeritus maintainers were marked as codeowners.