### PR TITLE
Added first shot at a Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file
+# REF: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
As promised in PR #284 I would make a separate PR for a proposal for a [Dependabot](https://github.com/dependabot) configuration.

This is the configuration I use myself, it is only aimed at GitHub Actions, since I do not know anything about your project in general.

The PR enables use of Dependabot, which will scheduled intervals will create PRs for you to review and possibly merge. Since you only have one action at this time, you will not receive many PRs from Dependabot. I must admit I like to keep the schedule on a weekly basis, but you can alter this to fit your schedule.

This is a very basic configuration, which works well for me, more [documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot) is available (also linked in the code as a comment, something I find very convenient, when it is not your core project and not something you work on every day..

As for using it for Docker, I am using Dependabot's Docker capability as well in the form:

```yaml
  # Enable version updates for Docker
  - package-ecosystem: "docker"
    # Look for a `Dockerfile` in the `root` directory
    directory: "/"
    # Check for updates once a week
    schedule:
      interval: "weekly"
```

I did not want to impose this on you in my PR, as stated I do not know about if this could be of value to you, your project and in context of you Docker use. I will let you decide and adapt.

I have just release 0.20.0 of the Spellcheck GitHub Action, so if you enable Dependabot, you should receive a PR shortly.

Please use the PR as you see fit, change it, adjust it or discard it.