### PR TITLE
Add Korean approvers in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,9 @@
 # We require at least two maintainers to sign off on a new term
 
 * @caniszczyk @CathPag @jasonmorgan 
+
+
+# These are the approvers for localization contents
+# in each `/content/language/` directory
+
+/content/ko/ @seokho-son @Eviekim @jihoon-seo


### PR DESCRIPTION
A task based on the issue #288 (Initiate Korean Localization Team)

This PR is to check the setting for approvers for localization contents in each `/content/language/` directory works properly.

With this setting I am going to test localization procedures of Korean l10n (`dev-ko` branch). 
