### PR TITLE
Update settings.yml for dev-ko branch protection

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -41,3 +41,13 @@ branches:
       restrictions:
         users:
          - edsoncelio
+  - name: dev-ko
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+      restrictions:
+        users:
+         - seokho-son
+         - Eviekim
+         - jihoon-seo
+ 


### PR DESCRIPTION
This PR updates

settings.yml for `dev-ko` branch protection rule and approvers.

I am not sure this configuration works, but we can check after this PR's been merged.