### PR TITLE
Fix configuration for branch protection

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -25,29 +25,59 @@ collaborators:
     permission: admin
 
   - username: CathPag
-    permission: push
+    permission: maintain
     
   - username: seokho-son
-    permission: push
+    permission: admin
     
   - username: murillodigital
-    permission: push
+    permission: maintain
+
+  # l10n ko approvers
+  # Note: seokho-son is both a maintainer (maintain) and Korean approver (push)
+  - username: jihoon-seo
+  permission: push
+
+  - username: Eviekim
+  permission: push
+
     
 branches:
-  - name: portuguese
+
+  # Default branch of this repository for configurations and English contents
+  - name: main
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
       restrictions:
+        apps: []
+        # En approvers (including Chairs)
         users:
-         - edsoncelio
+         - caniszczyk
+         - jasonmorgan
+         - CathPag
+         - seokho-son
+         - murillodigital
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for Korean contents only
   - name: dev-ko
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
       restrictions:
+        apps: []
+        # Ko approvers
         users:
          - seokho-son
          - Eviekim
          - jihoon-seo
- 
+        teams: []
+      enforce_admins: null
+      required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -29,9 +29,6 @@ collaborators:
     
   - username: seokho-son
     permission: admin
-    
-  - username: murillodigital
-    permission: maintain
 
   # l10n ko approvers
   # Note: seokho-son is both a maintainer (maintain) and Korean approver (push)
@@ -59,7 +56,6 @@ branches:
          - jasonmorgan
          - CathPag
          - seokho-son
-         - murillodigital
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,13 @@
 
-# These are the maintainers in the repo 
-# We require at least two maintainers to sign off on a new term
+# These are the maintainers in the repo.
+# These owners will be the default owners for everything in the repo.
+# We require at least two maintainers to sign off on a new term.
 
-* @caniszczyk @CathPag @jasonmorgan 
+* @caniszczyk @CathPag @jasonmorgan @murillodigital @seokho-son
 
 
-# These are the approvers for localization contents
-# in each `/content/language/` directory
+# These are the owners for localization contents
+# in each `/content/language/` directory.
 
+# Owners of Korean contents
 /content/ko/ @seokho-son @Eviekim @jihoon-seo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the repo.
 # We require at least two maintainers to sign off on a new term.
 
-* @caniszczyk @CathPag @jasonmorgan @murillodigital @seokho-son
+* @caniszczyk @CathPag @jasonmorgan @seokho-son
 
 
 # These are the owners for localization contents


### PR DESCRIPTION
The current settings for branch protection seems not work properly.
(I think some settings of https://github.com/apps/settings are not stable yet)

This PR updates `.github/settings.yml` and `CODEOWNERS` to fix configuration on branch protection.
I also suggest following configuration for permission.
- All maintainers (admins) have push permission to all branches.
- Approvers for each localization team have push permission to corresponding development branch (e.g. `dev-ko`)
  - but they cannot push a commit for files not related with localization contents unless an appropriate owner(reviewer) in CODEOWNERS gives an approving review.
  - they cannot push a commit to `main` branch

I'v tested `https://github.com/apps/settings` with a similar configuration in another organization :) 
I hope this PR resolves all :)

Please note that
- I temporally set myself as one of `admin` to check this setting by `https://github.com/apps/settings` works properly. (we can check this from `setting` tap)
- I intentionally removed branch setting for Portuguese temporally. (Let's check configuration for Korean branch works firstly)