### PR TITLE
Add approvers for localization contents

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -76,6 +76,19 @@ collaborators:
   - username: sistella
     permission: push
 
+  # l10n ar approvers
+  - username: TarekMSayed
+    permission: push
+
+  - username: same7ammar
+    permission: push
+
+  - username: AShabana
+    permission: push
+
+  - username: hacktron95
+    permission: push
+
 branches:
 
   # Default branch of this repository for configurations and English contents
@@ -187,3 +200,21 @@ branches:
       enforce_admins: null
       required_linear_history: null
 
+  # l10n branch for ar contents only
+  - name: dev-ar
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # ar approvers
+        users:
+         - TarekMSayed
+         - same7ammar
+         - AShabana
+         - hacktron95
+        teams: []
+      enforce_admins: null
+      required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -38,6 +38,12 @@ collaborators:
   - username: Eviekim
     permission: push
 
+  # l10n pt approvers
+  - username: edsoncelio
+    permission: push
+
+  - username: brunoguidone
+    permission: push
     
 branches:
 
@@ -77,3 +83,21 @@ branches:
         teams: []
       enforce_admins: null
       required_linear_history: null
+
+  # l10n branch for pt contents only
+  - name: dev-pt
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # pt approvers
+        users:
+         - edsoncelio
+         - brunoguidone
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -44,6 +44,19 @@ collaborators:
 
   - username: brunoguidone
     permission: push
+
+  # l10n hi approvers
+  - username: Garima-Negi
+    permission: push
+
+  - username: sayantani11
+    permission: push
+
+  - username: anubha-v-ardhan
+    permission: push
+
+  - username: jayesh-srivastava
+    permission: push
     
 branches:
 
@@ -97,6 +110,25 @@ branches:
         users:
          - edsoncelio
          - brunoguidone
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for hi contents only
+  - name: dev-hi
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # hi approvers
+        users:
+         - Garima-Negi
+         - sayantani11
+         - anubha-v-ardhan
+         - jayesh-srivastava
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -57,7 +57,13 @@ collaborators:
 
   - username: jayesh-srivastava
     permission: push
-    
+
+  # l10n de approvers
+  # Note: CathPag is both a maintainer (maintain) and de approver (push)
+  - username: iamNoah1
+    permission: push
+
+
 branches:
 
   # Default branch of this repository for configurations and English contents
@@ -129,6 +135,23 @@ branches:
          - sayantani11
          - anubha-v-ardhan
          - jayesh-srivastava
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for de contents only
+  - name: dev-de
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # de approvers
+        users:
+         - CathPag
+         - iamNoah1
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -63,6 +63,18 @@ collaborators:
   - username: iamNoah1
     permission: push
 
+  # l10n it approvers
+  - username: Giulia-dipietro
+    permission: push
+
+  - username: meryem-ldn
+    permission: push
+
+  - username: annalisag-spark
+    permission: push
+
+  - username: sistella
+    permission: push
 
 branches:
 
@@ -152,6 +164,25 @@ branches:
         users:
          - CathPag
          - iamNoah1
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for it contents only
+  - name: dev-it
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # it approvers
+        users:
+         - Giulia-dipietro
+         - meryem-ldn
+         - annalisag-spark
+         - sistella
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -89,6 +89,16 @@ collaborators:
   - username: hacktron95
     permission: push
 
+  # l10n bn approvers
+  - username: mitul3737
+    permission: push
+
+  - username: Mouly22
+    permission: push
+
+  - username: ikramulkayes
+    permission: push
+
 branches:
 
   # Default branch of this repository for configurations and English contents
@@ -215,6 +225,24 @@ branches:
          - same7ammar
          - AShabana
          - hacktron95
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for bn contents only
+  - name: dev-bn
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # bn approvers
+        users:
+         - mitul3737
+         - Mouly22
+         - ikramulkayes
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,7 @@
 
 # Owners of Korean contents
 /content/ko/ @seokho-son @Eviekim @jihoon-seo
+
+# Owners of Portuguese contents
+/content/pt/ @edsoncelio @brunoguidone
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,3 +26,6 @@
 
 # Owners of Arabic contents
 /content/ar/ @TarekMSayed @same7ammar @AShabana @hacktron95
+
+# Owners of Bengali contents
+/content/bn/ @mitul3737 @Mouly22 @ikramulkayes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,3 +15,7 @@
 # Owners of Portuguese contents
 /content/pt/ @edsoncelio @brunoguidone
 
+# Owners of Hindi contents
+/content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava
+
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,6 @@
 # Owners of Hindi contents
 /content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava
 
+# Owners of German contents
+/content/de/ @CathPag @iamNoah1
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,3 +23,6 @@
 
 # Owners of Italian contents
 /content/it/ @Giulia-dipietro @meryem-ldn @annalisag-spark @sistella
+
+# Owners of Arabic contents
+/content/ar/ @TarekMSayed @same7ammar @AShabana @hacktron95

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,3 +21,5 @@
 # Owners of German contents
 /content/de/ @CathPag @iamNoah1
 
+# Owners of Italian contents
+/content/it/ @Giulia-dipietro @meryem-ldn @annalisag-spark @sistella


### PR DESCRIPTION

Based on l10n team initiation requests, I added approvers for each language.
(https://github.com/cncf/glossary/projects/2)

- Add Portuguese approvers (@edsoncelio @brunoguidone)
- Add Hindi approvers (@Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava)
- Add German approvers (@CathPag @iamNoah1)
- Add Italian approvers (@Giulia-dipietro @meryem-ldn @annalisag-spark @sistella)
- Add Arabic approvers (@TarekMSayed @same7ammar @AShabana @hacktron95)
- Add Bengali approvers (@mitul3737 @Mouly22 @ikramulkayes)

---

This is the current permission setting. I checked this setting with Korean l10n team through https://github.com/cncf/glossary/pull/334.
If this configuration is acceptable by maintainers, we can update this setting for all l10n teams. 

**[PR merge condition to main branch]**
1. only chairs can merge PR to main branch (caniszczyk, jasonmorgan, CathPag, seokho-son)
   https://github.com/cncf/glossary/blob/main/.github/settings.yml#L55
2. at least one of codeowners should give approving review
   - codeowners for all files including English contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L6 (same as chairs)
3. at least 2 approving reviews are required from approvers.
4. l10n team approvers can give approving review to PR for any file. (but they should not)
   - Ref: https://github.com/cncf/glossary/pull/325#issuecomment-1015024262
   - but since they are not mean to be a reviewer or approver of English contents, we need to guide them not to approve PRs not related with their own l10n.
   - even though l10n team approvers give approving review, they CANNOT merge PR to main branch. it is restricted. (Like this: https://github.com/cncf/glossary/pull/325#issuecomment-1015026130)
   - I don't like this policy. We will probably have to evolve it over time. Anyway the main branch will be safe by the chairs

**[PR merge condition to dev-xx l10n branch (dev-ko)]**
1. chairs can merge PR to all branches (caniszczyk, jasonmorgan, CathPag, seokho-son)
2. at least one of l10n codeowners should give approving review
    - codeowners for Korean contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L13 (same as Korean approvers)
    - if a PR includes files outside of Koean l10n, chairs need to review and merge.
3. at least 2 approving reviews are required from l10n approvers.
4. l10n teams can merge PRs for their dev branch. If a PR includes files outside of l10n contents, They need to get an approval from maintainers (maintainers are codeowners for all files)

**The l10n approvers need to aware following policy.**
```
The approvers of l10n team will have a push permission to this repository.
It is to make l10n approvers manage (merge) PRs for l10n contributions in your development branch.
Merging a PR to the `main` branch by l10n approvers is restricted.
Even if they are possible to review a PR to the `main` branch and give an approval to the PR, they should not approve the PR. 
So, please do not approve if a PR is not related with your localization.
```

---

I hope to note that we are using the CODEOWNERS to automatically request a review to appropriate persons.
(https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about[…]owners)

The actual access permission can be configured from the repository setting (cncf/glossary repo).
- We can change access permission using Github UI. But we are using https://github.com/apps/settings App.
- https://github.com/apps/settings App syncs repository settihngs defined in https://github.com/cncf/glossary/blob/main/.github/settings.yml