### PR TITLE
Update Client-Server Architecture to provide example of desktop application and removing wording that suggests that desktop applications came before client-server architectures

### DIFF
--- a/content/en/client_server_architecture.md
+++ b/content/en/client_server_architecture.md
@@ -6,7 +6,9 @@ category: concept
 
 ## What it is
 
-In a client-server architecture, the logic (or code)  that makes up an application is split between two or more components: a client that asks for work to be done (e.g. the Gmail web application running in your web browser), and one or more servers that satisfy that request (e.g. the "send email" service running on Google’s computers in the cloud). This contrasts with legacy applications which were typically self-contained (such as desktop apps in the 1990’s) and did all the work in one place (in our example the email is sent by Google’s computers rather than your own).
+In a client-server architecture, the logic (or code) that makes up an application is split between two or more components: a client that asks for work to be done (e.g. the Gmail web application running in your web browser), and one or more servers that satisfy that request (e.g. the "send email" service running on Google’s computers in the cloud). In this example, outgoing emails that you write are sent by the client (web application running in your web browser) to a server (Gmail's computers, which forward your outgoing emails to their recipients).
+
+This contrasts with self-contained applications (such as desktop applications) that do all the work in one place. For example, a word processing program like Microsoft Word may be installed and run entirely on your computer.
 
 ## Problem it addresses 
 


### PR DESCRIPTION
The current wording in the client-server architecture document somewhat implies that self-contained applications came before client-server applications and that they are no longer in use (via the use of the word "legacy").

Being sensitive to this glossary focusing on CNCF technologies, I removed the word "legacy" and replaced it with a slightly more elaborate description of a self-contained application (desktop app) to clearly distinguish client-server from self-contained apps.