### PR TITLE
 Settings and initial contents for Spanish localization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,13 @@ weight = 1
 #time_format_default = "02.01.2006"
 #time_format_blog = "02.01.2006"
 
+[languages.es]
+title = "Cloud Native Glosario"
+description = "El proyecto de CNCF Cloud Native Glosario pretende ser usado como una referencia para los terminos comunes usados cuando se habla acerca de las aplicaciones nativas para la nube."
+languageName ="Español(Spanish)"
+weight = 2
+contentDir = "content/es"
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/content/es/_index.md
+++ b/content/es/_index.md
@@ -1,0 +1,24 @@
+
+---
+title: "Glosario Cloud Native"
+---
+
+# Glosario Cloud Native
+
+El Glosario Cloud Native es un proyecto liderado por la CNCF Business Value Subcommittee (BVS). Su meta es explicar los conceptos nativos para la nube en un lenguaje claro y simple sin recurrir a cualquier conocimiento técnico previo.
+
+## Contribuyendo
+Todo mundo esta invitado a sugerir cambios, adiciones, y mejoras a el Glosario Cloud Native. Empleamos un proceso guiado por la comunidad y gobernado por la CNCF para desarrollar y mejorar este léxico compartido. Este Glosario provee una plataforma neutral de vendedores para organizar un vocabulario compartido alrededor de las tecnologías nativas para la nube. Las contribuciones son bienvenidas de todos los participantes que cumplan con el propósito y los estatutos del proyecto.
+
+Cualquier persona que desee hacer una contribución puede enviar un GitHub issue o crear un pull request. Asegúrese de seguir la [Guía de estilo](/style-guide/), leer el documento de [Cómo contribuir](/contribute/) y unirse al canal de #glossary en el CNCF Slack. También hay un canal #glossary-localizations para aquellos que quieran ayudar a traducir el glosario a su idioma.
+
+## Reconocimientos
+
+El Glosario Cloud Native fue iniciado por CNCF Marketing
+Committee (Business Value Subcommittee) e incluye
+contribuciones de [Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), [Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/),
+[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk), [Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), [Katelin Ramer](https://www.linkedin.com/in/katelinramer/), [Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca), [Seokho Son](https://www.linkedin.com/in/seokho-son/) y muchos contribuidores mas. Para una lista de contribuidores completa, consulte [esta página de GitHub](https://github.com/cncf/glossary/graphs/contributors).
+
+## Licencia
+
+Todas las contribuciones de código están bajo la licencia Apache 2.0. La documentación se distribuye bajo CC BY 4.0.

--- a/content/es/contribute/_index.md
+++ b/content/es/contribute/_index.md
@@ -1,0 +1,111 @@
+---
+title: Como contribuir
+toc_hide: true
+menu:
+  main:
+    weight: 10
+    pre: <i class='fas fa-pen-square'></i>
+---
+
+El contenido del Glosario Cloud Native se almacena en [este repositorio de GitHub](https://github.com/cncf/glossary) donde encontrará una lista de [issues](https://github.com/cncf/glossary/issues), [PRs](https://github.com/cncf/glossary/pulls) y [discusiones](https://github.com/cncf/glossary/discussions) sobre el glosario.
+
+Existen tres formas en las que puedes contribuir:
+
+1) Proponer nuevos términos
+2) Actualizar los existentes
+3) Ayudar a traducir el glosario
+
+## ¡Únete a la comunidad del glosario!
+Considere unirse a nuestras reuniones mensuales del Grupo de trabajo del glosario si es que desea contribuir con regularidad. Puede encontrar los detalles de la reunión en el calendario de la CNCF. También puede conectarse con los mantenedores y otros colaboradores en nuestro canal #glossary en el [calendario CNCF](https://www.cncf.io/calendar/). ¡Nos encantaría conocerlo!
+
+## Proponer nuevos términos
+Puede proponer un nuevo término para que otros trabajen en él o crear una nueva definición usted mismo. De cualquier forma, comenzará creando un issue (tenga en cuenta que necesitará una cuenta de GitHub para hacerlo).
+
+A continuación se muestra una guía paso a paso para aquellos que aún no están familiarizados con GitHub. **Si eres un profesional de GitHub**, *da* un vistazo rápido para asegurarte de que usas nuestras plantillas de issues, las convenciones de nomenclatura, solicita un PR en Slack (de lo contrario, podemos perderlo) y dónde encontrar la plantilla del archivo. Y asegúrese de leer la [Guía de estilo](https://glossary.cncf.io/style-guide/) antes de comenzar. ¡Gracias!
+
+### Creando un issue
+Vaya a los issues [del repositorio del Glosario en GitHub](https://github.com/cncf/glossary/issues) y haga clic en "New issue".
+
+![issues](/images/how-to/howto-01.png)
+
+Verá una variedad de plantillas. Para proponer un nuevo término en Español, seleccione "Spanish Language Glossary Request".
+
+![templates](/images/how-to/howto-02.png)
+
+Agregue la palabra que está sugiriendo y presione "submit new issue". Si solo está proponiendo un nuevo término, ¡ya está listo! Para trabajar en ello, siga los siguientes pasos.
+
+![new issue](/images/how-to/howto-03.png)
+
+Únase al canal de #glossary en el CNCF Slack y notifique a @Catherine Paganini, @jmo y @Seokho Son que ha enviado un issue y que le gustaría trabajar en él. Ellos le asignarán el problema a usted, indicando a todos los demás que el término ya ha sido tomado.
+
+Aquí puede ver que los primeros tres términos están disponibles mientras que el siguiente término ha sido asignado a alguien.
+
+![assigning a term](/images/how-to/howto-04.png)
+
+Tenga en cuenta que solo puede reclamar un término a la vez. Si desea trabajar en varios términos, termine uno antes de reclamar el siguiente.
+
+### Envío de un nuevo término (creando un PR)
+
+Antes de comenzar, lea la [Guía de estilo](https://glossary.cncf.io/style-guide/) — le ayudará a minimizar el ir de un lado a otro. Como se indica en la guía de estilo, recomendamos encarecidamente el comenzar con un documento de Google o Word.
+
+Una vez que el término esté listo para ser enviado, vaya a la carpeta de content (en la seccion de Code)…
+
+![content](/images/how-to/howto-05.png)
+
+…luego "es" …
+
+![language folder](/images/how-to/howto-06.png)
+
+…y seleccione _TEMPLATE.md
+
+![template](/images/how-to/howto-07.png)
+
+Copie el contenido…
+
+![copy content](/images/how-to/howto-08.png)
+
+…y vaya atras de la carpeta "es". Presione "add file" y seleccione "create new file."
+
+![create new file](/images/how-to/howto-09.png)
+
+Agregue el nombre del término en la URL (sin mayúsculas ni espacios) y .md al final (nota: si su vista previa no funciona, probablemente olvidó agregar .md al final). A continuación pegue el contenido de la plantilla. Copie y pegue su definición en el archivo. Tenga en cuenta que GitHub usa Markdown para formatear el texto (p. ej., hipervínculo, negrita, cursiva). Consulte esta [hoja de referencia para markdown](https://www.markdownguide.org/cheat-sheet/). Para verificar que usó Markdown según lo pensado, vaya a "vista previa". 
+
+![finalize term](/images/how-to/howto-10.png)
+
+Desplácese hacia abajo y asigne un nombre al nuevo archivo de confirmación cuando esté listo para enviarlo. Ahora está a punto de asignar el término a su propio branch. Para enviar el PR se requiere un paso adicional. Presiona "commit new file" y... 
+
+![commit new file](/images/how-to/howto-11.png)
+
+…ahora you estas creando un PR:
+
+![create a pr](/images/how-to/howto-12.png)
+
+Ahora debería ver su PR en "Pull requests."
+
+![prs](/images/how-to/howto-13.png)
+
+## Actualizando un término existente
+Para actualizar un término existente, puede sugerir un cambio a través de un issue o continuar y actualizar el término directamente enviando un pull request (PR). 
+
+### Solicitar un cambio a través de un issue
+Si desea marcar un problema con un término pero no sabe cómo hacerlo o desea solucionarlo usted mismo, haga clic en "Reportar un issue".
+
+![report issue](/images/how-to/howto-14.png)
+
+Esto abrirá directamente un issue. Explique qué cambio es necesario y por qué. Presiona enviar, y eso es todo.
+
+![submit issue](/images/how-to/howto-15.png)
+
+### Actualizar un término directamente
+Para cambiar un término directamente, vaya a "Editar esta página".
+
+![edit this page](/images/how-to/howto-16.png)
+
+Esto abrirá la página de término en GitHub. Realice sus cambios y envíe un PR. Consulte "Envío de un nuevo término" más arriba para obtener una descripción mas detallada (salte a la sección que habla acerca de markdown).
+
+## Ayuda a traducir el glosario
+Para ayudar a traducir el glosario a su idioma, únase al canal #glossary-localizations en CNCF Slack y háganoslo saber. Puede unirse a un equipo existente o crear uno nuevo (para ver lo que se necesita, consulte la [Guía de localización](https://github.com/cncf/glossary/blob/main/LOCALIZATION.md)). Únase también a nuestras juntas mensuales del grupo de trabajo. Puede encontrar mas detalles en el [calendario de la CNCF]((https://www.cncf.io/calendar/). ¡Esperamos verte allí!
+
+
+
+

--- a/content/es/style-guide/_index.md
+++ b/content/es/style-guide/_index.md
@@ -1,0 +1,131 @@
+---
+title: Guia de estilos
+toc_hide: true
+menu:
+  main:
+    weight: 10
+    pre: <i class='fas fa-ruler-horizontal'></i>
+---
+
+Esta guia de estilos te ayudará a entender la audiencia del Glosario, la estructura de las definiciones, el nivel de detalle requerido, y como mantener un estilo consistente.
+
+El Glosario Cloud Native sigue las [guias de estilo por defecto](https://github.com/cncf/foundation/blob/master/style-guide.md) del repositorio de CNCF. Adicionalmente, sigue las siguientes reglas:
+
+1. Utilice un lenguaje sencillo y accesible, evitando la jerga técnica y palabras de moda.
+2. [Evite el lenguaje coloquial](https://en.wikipedia.org/wiki/Colloquialism)
+3. [Use un lenguaje literal y concreto](http://guidetogrammar.org/grammar/composition/abstract.htm)
+4. [Omite contracciones](https://en.wikipedia.org/wiki/Contraction_(grammar))
+5. [Use la voz pasiva con moderación] (https://www.ef.com/ca/english-resources/english-grammar/passive-voice/)
+6. [Trate de formular declaraciones en forma positiva] (https://examples.yourdictionary.com/positive-sentence-examples.html)
+7. [Sin signos de exclamación fuera de las comillas] (https://www.grammarly.com/blog/exclamation-mark/)
+8. No exageres
+9. Evite repetir
+10. Sea conciso
+
+## Audiencia
+
+El Glosario está escrito para una audiencia técnica Y no técnica. Asegúrese de que las definiciones sean explicadas en términos simples y no asuma conocimientos técnicos. Más acerca de eso a continuación en Definición.
+
+## Plantilla de definición
+
+Cada término del glosario es almacenado en un archivo de markdown y utiliza esta plantilla:
+
+```md
+---
+title:
+status:
+category:
+---
+
+## Que es
+
+Un breve resumen de la tecnología o concepto.
+
+## Problema que aborda
+
+Unas líneas sobre el problema que está abordando.
+
+## Cómo ayuda
+
+Unas pocas líneas sobre cómo la cosa resuelve el problema.
+```
+
+### Title
+
+La etiqueta **title** siempre estará en la parte superior de una definición y su valor debe estar en mayúsculas y minúsculas.
+
+```md
+---
+title: Plantilla de Definición
+```
+
+### Status
+
+La etiqueta **status** vendrá después de la etiqueta del título. La etiqueta de estado indica si las definiciones están minuciosamente examinadas o requieren más esfuerzo.
+
+Los valores válidos son:
+
+- Completed (Completado)
+- Feedback Appreciated (Retroalimentacion solicitada)
+- Not Started (Sin iniciar)
+
+Siempre puede abrir un issue a una definición completa. Mientras una definición está cambiando, su estado cambiará a *Feedback Appreciated*.
+
+```md
+---
+title: Plantilla de Definición
+status: Feedback Appreciated
+```
+
+### Category
+
+La etiqueta de **category** vendrá después de la etiqueta de estado. Su valor debe ser uno de los siguientes valores:
+
+- Technology
+- Property
+- Concept
+
+```md
+---
+title: Plantilla de Definición
+status: Feedback Appreciated
+category: Concept
+---
+```
+
+### Definición
+
+#### Tres subrúbricas
+
+Las definiciones de las categorías **technology** y **concept** contienen tres subrúbricas:
+
+- **Qué es**: proporciona una descripción breve y clara de lo que estamos hablando.
+- **Problema que aborda**: enfocate en el problema, no en la solución (que viene en la siguiente sección). De hecho, evite mencionar el término que se esta definiendo. El problema se centra en *qué* nos llevó a necesitar esto.
+- **Cómo ayuda**: ahora, vuelve al término. ¿Cómo aborda el problema descrito anteriormente?
+
+Tenga en cuenta que la etiqueta **properties** no requiere secciones separadas. Una definición será suficiente.
+
+#### Manteniéndolo simple
+
+El Glosario tiene como objetivo **explicar conceptos complejos en palabras sencillas**; esta es una tarea sorprendentemente difícil que probablemente requerirá múltiples revisiones. Siempre tenga en cuenta a la audiencia cuando redacte su definición. Evite usar términos de la industria y palabras de moda; probablemente se encontrará volviendo a ellos y es posible que deba corregirlos automáticamente.
+
+Cuando corresponda, use **ejemplos del mundo real** que ayuden a los lectores (especialmente a los no técnicos) a comprender mejor *cuándo* y *por qué* el concepto que está explicando es relevante.
+
+Cuando se use en su definición, siempre **enlace a los términos existentes del glosario** (solo la primera mención debe tener un hipervínculo).
+
+**Ejemplo**: eche un vistazo a la sección "Qué es" de la [definición de service mesh](https://glossary.cncf.io/service_mesh/). Se vincula con las definiciones de microservicios, servicio, confiabilidad y observabilidad. Además, utiliza un ejemplo del mundo real que compara los desafíos de la red en un entorno de microservicios (algo con lo que las personas no técnicas no pueden relacionarse) con los problemas de wifi (algo que cualquiera que use una computadora portátil puede entender). Siempre que sea posible, trate de hacer esa conexión.
+
+#### Comience con un documento de Google o Word
+
+Recomendamos comenzar con un documento de Google o Word, dejalo pasar durante unos días y volver a visitarlo. Esto te permitirá captar frases o expresiones que podrían redactarse de una forma más sencilla y accesible. Además, asegúrese de ejecutar un corrector ortográfico antes de enviar un PR.
+
+Para asegurarse de que nadie más envíe un PR mientras trabaja en un término, asegúrese de reclamar un issue (o crear uno) y que se le asigne. Más sobre eso en el documento [Cómo contribuir](https://glossary.cncf.io/contribute/).
+
+Antes de comenzar, lea algunos de los términos publicados del Glosario para tener una idea del nivel de detalle y dificultad y cuándo los ejemplos son apropiados.
+
+
+## El proceso de revisión: qué esperar
+
+Tenga en cuenta que actualmente solo hay tres mantenedores haciendo esto en su tiempo libre. Ocasionalmente, podremos revisar los términos rápidamente; en otras ocasiones, puede llevar algo de tiempo. Agradecemos su paciencia. Si tiene alguna pregunta, comuníquese con nosotros en el canal #glossary de Slack (para saber dónde y cómo encontrarlo, consulte nuestro documento de [Cómo contribuir](https://glossary.cncf.io/contribute/)).
+
+Nuestro objetivo es que el Glosario sea el mejor recurso posible. Una vez que envíe un PR, podemos solicitar una o más revisiones. No se sienta frustrado, ese es el caso de muchos relaciones públicas. Esas idas y venidas y nuestra colaboración asegurarán que su contribución se convierta en una definición verdaderamente útil leída y referida por lectores de todo el mundo.

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,0 +1,61 @@
+
+
+# UI strings. Buttons and similar.
+
+[ui_pager_prev]
+other = "Anterior"
+
+[ui_pager_next]
+other = "Siguiente"
+
+[ui_read_more]
+other = "Leer más"
+
+[ui_search]
+other = "Buscar en este sitio…"
+
+# Used in sentences such as "Posted in News"
+[ui_in]
+other = "en"
+
+# Used in sentences such as "All Tags"
+[ui_all]
+other = "todo(a)"
+
+# Footer text
+[footer_all_rights_reserved]
+other = "Todos los derechos reservados"
+
+[footer_privacy_policy]
+other = "Política de privacidad"
+
+
+# Post (blog, articles etc.)
+[post_byline_by]
+other = "Por"
+[post_created]
+other = "Creado"
+[post_last_mod]
+other = "Modificado(a) por última vez"
+[post_edit_this]
+other = "Editar esta página"
+[post_create_child_page]
+other = "Crear página hija"
+[post_create_issue]
+other = "Reportar un issue"
+[post_create_project_issue]
+other = "Crear un issue en el proyecto"
+[post_posts_in]
+other = "Publicar en"
+[post_reading_time]
+other = "minuto(s) de lectura"
+
+# Print support
+[print_printable_section]
+other = "Esta es una página con vista imprimible de esta sección."
+[print_click_to_print]
+other = "Presiona aquí para imprimir"
+[print_show_regular]
+other = "Regresar a la vista regular de esta página"
+[print_entire_section]
+other = "Imprimir la sección completa"


### PR DESCRIPTION
This PR is to initiate Spanish localization based on

* Issue to #387 
* https://github.com/cncf/glossary/blob/main/LOCALIZATION.md guide

Base and target branch of this PR is dev-es which is development branch for Spanish localization.

This PR includes

- [languages.es] section in config.toml
- i18n/es.toml
- Some translated documents
  - Main page
    - content/es/_index.md
  - Others
    - contribute: content/es/contribute/_index.md
    - style-guide: content/es/style-guide/_index.md