### PR TITLE
Add localization team approvers (ar bn es pt ko)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -38,11 +38,17 @@ collaborators:
   - username: Eviekim
     permission: push
 
+  - username: yunkon-kim
+    permission: push
+
   # l10n pt approvers
   - username: edsoncelio
     permission: push
 
   - username: brunoguidone
+    permission: push
+
+  - username: jessicalins
     permission: push
 
   # l10n hi approvers
@@ -80,9 +86,35 @@ collaborators:
     permission: push
 
   # l10n ar approvers
+  - username: TarekMSayed
+    permission: push
+
+  - username: same7ammar
+    permission: push
+
+  - username: AShabana
+    permission: push
+
+  - username: hacktron95
+    permission: push
 
   # l10n bn approvers
+  - username: mitul3737
+    permission: push
 
+  - username: Mouly22
+    permission: push
+
+  - username: ikramulkayes
+    permission: push
+
+  # l10n es approvers
+  # Note: CathPag is both a maintainer (maintain) and de approver (push)
+  - username: raelga
+    permission: push
+    
+  - username: electrocucaracha
+    permission: push
 
 branches:
 
@@ -119,6 +151,7 @@ branches:
          - seokho-son
          - Eviekim
          - jihoon-seo
+         - yunkon-kim
         teams: []
       enforce_admins: null
       required_linear_history: null
@@ -136,6 +169,7 @@ branches:
         users:
          - edsoncelio
          - brunoguidone
+         - jessicalins
         teams: []
       enforce_admins: null
       required_linear_history: null
@@ -207,7 +241,10 @@ branches:
         apps: []
         # ar approvers
         users:
-         - seokho-son
+         - TarekMSayed
+         - same7ammar
+         - AShabana
+         - hacktron95
         teams: []
       enforce_admins: null
       required_linear_history: null
@@ -223,7 +260,27 @@ branches:
         apps: []
         # bn approvers
         users:
-         - seokho-son
+         - mitul3737
+         - Mouly22
+         - ikramulkayes
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for es contents only
+  - name: dev-es
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # es approvers
+        users:
+         - CathPag
+         - raelga
+         - electrocucaracha
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,10 +10,10 @@
 # in each `/content/language/` directory.
 
 # Owners of Korean contents
-/content/ko/ @seokho-son @Eviekim @jihoon-seo
+/content/ko/ @seokho-son @Eviekim @jihoon-seo @yunkon-kim
 
 # Owners of Portuguese contents
-/content/pt/ @edsoncelio @brunoguidone
+/content/pt/ @edsoncelio @brunoguidone @jessicalins
 
 # Owners of Hindi contents
 /content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava
@@ -25,7 +25,10 @@
 /content/it/ @Giulia-dipietro @meryem-ldn @annalisag-spark @sistella
 
 # Owners of Arabic contents
-# /content/ar/ @TarekMSayed @same7ammar @AShabana @hacktron95
+/content/ar/ @TarekMSayed @same7ammar @AShabana @hacktron95
 
 # Owners of Bengali contents
-# /content/bn/ @mitul3737 @Mouly22 @ikramulkayes
+/content/bn/ @mitul3737 @Mouly22 @ikramulkayes
+
+# Owners of Spanish contents
+/content/es/ @CathPag @raelga @electrocucaracha


### PR DESCRIPTION
Based on l10n team initiation requests, I added [localization approvers](https://glossary.cncf.io/contributor-ladder/#localization-approvers) for each language.
(https://github.com/cncf/glossary/projects/2)



- Add Arabic approvers #326
  - [x] Tarek M. Sayed (@TarekMSayed)
  - [x] Sameh Ammar (@same7ammar)
  - [x] Ahmed Shabana (@AShabana)
  - [x] Osama Nabil (@hacktron95)
- Add Bengali approvers #339
  - [x] MD. Shahriyar Al Mustakim Mitul ( @mitul3737 )
  - [x] Umme Abira Azmary ( @Mouly22 )
  - [x] MD Ikramul Kayes ( @ikramulkayes )
- Add Spanish approvers #387
  - [x] Catherine Paganini (@CathPag)
  - [x] Rael Garcia (@raelga)
  - [x] Victor Morales (@electrocucaracha)
- Add Portuguese approver #290
  - [x] Jéssica Lins (@jessicalins)
- Add Korean approver #288
  - [x] [A] Yunkon Kim (@yunkon-kim)

**[Important]**
 - All candidates need to **leave a comment** that you understood overall policy.
 - The l10n team approvers need to **use your permission appropriately**.
   - The approvers of l10n team will have a push permission to this repository.
It is to make l10n approvers manage (merge) PRs for l10n contributions in your development branch.
Merging a PR to the `main` branch by l10n approvers is restricted.
Even if they are possible to review a PR to the `main` branch and give an approval to the PR, they should not approve the PR. 
So, please do not approve if a PR is not related with your localization.
 - After this PR merged, the approvers will get an **github invitation** for collaborate from settings[bot] of cncf/glossary. You need to accept. 

---


**[PR merge condition to main branch]**
1. only chairs can merge PR to main branch 
2. at least one of codeowners should give approving review
   - codeowners for all files including English contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L6 (same as chairs)
3. at least 2 approving reviews are required from approvers.
4. l10n team approvers can give approving review to PR for any file. (but they should not)
   - Ref: https://github.com/cncf/glossary/pull/325#issuecomment-1015024262
   - but since they are not mean to be a reviewer or approver of English contents, we need to guide them not to approve PRs not related with their own l10n.
   - even though l10n team approvers give approving review, they CANNOT merge PR to main branch. it is restricted. (Like this: https://github.com/cncf/glossary/pull/325#issuecomment-1015026130)
   - We will probably have to evolve it over time. Anyway the main branch will be safe by the chairs

**[PR merge condition to dev-xx l10n branch (dev-ko)]**
1. chairs can merge PR to all branches (caniszczyk, jasonmorgan, CathPag, seokho-son)
2. at least one of l10n codeowners should give approving review
    - codeowners for Korean contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L13 (same as Korean approvers)
    - if a PR includes files outside of Koean l10n, chairs need to review and merge.
3. at least 2 approving reviews are required from l10n approvers.
4. l10n teams can merge PRs for their dev branch. If a PR includes files outside of l10n contents, They need to get an approval from maintainers (maintainers are codeowners for all files)

---

I hope to note that we are using the CODEOWNERS to automatically request a review to appropriate persons.
(https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about[…]owners)

The actual access permission can be configured from the repository setting (cncf/glossary repo).
- We can change access permission using Github UI. But we are using https://github.com/apps/settings App.
- https://github.com/apps/settings App syncs repository settihngs defined in https://github.com/cncf/glossary/blob/main/.github/settings.yml