### PR TITLE
Create code-of-conduct.md

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+The [CNCF](https://www.cncf.io/) Cloud Native Glossary Project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
resolves #435

> Since Glossary project is under CNCF, it seems important to guide code-of-conduct of CNCF.
I think we can create code-of-conduct.md file that provides the link to https://github.com/cncf/foundation/blob/main/code-of-conduct.md