### PR TITLE
Improve accuracy of the virtual machine term

### DIFF
--- a/content/en/virtual_machine.md
+++ b/content/en/virtual_machine.md
@@ -6,7 +6,7 @@ category: Technology
 
 ## What it is
 
-A virtual machine (VM) is a computer and its operating system that is not bound to a particular piece of hardware. VMs rely on [virtualization](https://glossary.cncf.io/virtualization/) to carve a single physical computer into multiple virtual computers. That separation allows organizations and infrastructure providers to create and destroy VMs without impacting the underlying hardware — they’re simply files that can be easily created and deleted.
+A virtual machine (VM) is a computer and its operating system that is not bound to a particular piece of hardware. VMs rely on [virtualization](https://glossary.cncf.io/virtualization/) to carve a single physical computer into multiple virtual computers. That separation allows organizations and infrastructure providers to easily create and destroy VMs without impacting the underlying hardware.
 
 ## Problem it addresses
 


### PR DESCRIPTION
I think the existing definition for `virtual machine` term includes some incorrect description.

>A virtual machine (VM) is a computer and its operating system that is not bound to a particular piece of hardware. VMs rely on [virtualization](https://glossary.cncf.io/virtualization/) to carve a single physical computer into multiple virtual computers. That separation allows organizations and infrastructure providers to create and destroy VMs without impacting the underlying hardware — **they’re simply files** that can be easily created and deleted.



I know some files (such as VM image) are important properties to compose a VM, but it does not imply VM itself is just a file. 
Maybe, we can either say a VM is a process if VM is running. 

So, I suggest to remove ` — they’re simply files that can be easily created and deleted.` to improve accuracy of definition