### PR TITLE
Add new Glossary approvers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -29,12 +29,19 @@ collaborators:
     
   - username: seokho-son
     permission: admin
-
-  # l10n ko approvers
-  # Note: seokho-son is both a maintainer (maintain) and Korean approver (push)
+  
+  # English approvers (approver for all files in repository)
   - username: jihoon-seo
     permission: push
 
+  - username: iamNoah1
+    permission: push  
+  
+
+  # Localization approvers
+  # l10n ko approvers
+  # Note: seokho-son is both a maintainer (maintain) and Korean approver (push)
+  # Note: jihoon-seo is both English approver (push) and Korean approver (push)
   - username: Eviekim
     permission: push
 
@@ -66,9 +73,7 @@ collaborators:
 
   # l10n de approvers
   # Note: CathPag is both a maintainer (maintain) and de approver (push)
-  - username: iamNoah1
-    permission: push
-    
+  # Note: iamNoah1 is both English approver (push) and Korean approver (push)
   - username: DaveVentura
     permission: push
 
@@ -133,6 +138,8 @@ branches:
          - jasonmorgan
          - CathPag
          - seokho-son
+         - iamNoah1
+         - jihoon-seo
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -40,7 +40,7 @@ collaborators:
 
   # Localization approvers
   # l10n ko approvers
-  # Note: seokho-son is both a maintainer (maintain) and Korean approver (push)
+  # Note: seokho-son is both Maintainer (maintain) and Korean approver (push)
   # Note: jihoon-seo is both English approver (push) and Korean approver (push)
   - username: Eviekim
     permission: push
@@ -72,8 +72,8 @@ collaborators:
     permission: push
 
   # l10n de approvers
-  # Note: CathPag is both a maintainer (maintain) and de approver (push)
-  # Note: iamNoah1 is both English approver (push) and Korean approver (push)
+  # Note: CathPag is both Maintainer (maintain) and de approver (push)
+  # Note: iamNoah1 is both English approver (push) and de approver (push)
   - username: DaveVentura
     permission: push
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,34 +1,37 @@
+# This CODEOWNERS file defines contributors that are
+# responsible for code in this repository.
 
-# These are the maintainers in the repo.
-# These owners will be the default owners for everything in the repo.
-# We require at least two maintainers to sign off on a new term.
+# Code owners are automatically requested for review
+# when someone opens a pull request that modifies code that they own.
 
-* @caniszczyk @CathPag @jasonmorgan @seokho-son
+# These owners will be default owners for everything in this repository.
+# These owners consist of Maintainers and English approvers.
+* @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo
 
 
-# These are the owners for localization contents
+# These are the owners (approvers) for localization contents
 # in each `/content/language/` directory.
 
-# Owners of Korean contents
+# Approvers for Korean contents
 /content/ko/ @seokho-son @Eviekim @jihoon-seo @yunkon-kim
 
-# Owners of Portuguese contents
+# Approvers for Portuguese contents
 /content/pt/ @edsoncelio @brunoguidone @jessicalins
 
-# Owners of Hindi contents
+# Approvers for Hindi contents
 /content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava
 
-# Owners of German contents
+# Approvers for German contents
 /content/de/ @CathPag @iamNoah1 @DaveVentura
 
-# Owners of Italian contents
+# Approvers for Italian contents
 /content/it/ @Giulia-dipietro @meryem-ldn @annalisag-spark @sistella
 
-# Owners of Arabic contents
+# Approvers for Arabic contents
 /content/ar/ @TarekMSayed @same7ammar @AShabana @hacktron95
 
-# Owners of Bengali contents
+# Approvers for Bengali contents
 /content/bn/ @mitul3737 @Mouly22 @ikramulkayes
 
-# Owners of Spanish contents
+# Approvers for Spanish contents
 /content/es/ @CathPag @raelga @electrocucaracha


### PR DESCRIPTION
This PR is to add new Glossary approvers

@iamNoah1 and @jihoon-seo who have been actively contributed for the CNCF Glossary project. :)

The new English approvers will have write permission for all files in this Repository.

Note: @iamNoah1 and @jihoon-seo are involved in both English approver and localization approver. 
(@iamNoah1 `dev-de`, @jihoon-seo `dev-ko`)