### PR TITLE
Rename portuguese content dir from pt to pt-br

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@
 /content/ko/ @seokho-son @Eviekim @jihoon-seo @yunkon-kim
 
 # Approvers for Portuguese contents
-/content/pt/ @edsoncelio @brunoguidone @jessicalins
+/content/pt-br/ @edsoncelio @brunoguidone @jessicalins
 
 # Approvers for Hindi contents
 /content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava


### PR DESCRIPTION
This PR is just to rename the content dir to the Portuguese localization team from `content/pt` to `content/pt-br` and fix the codeowners file to get give the permissions to the right folder

After that, I'll open a PR to update the dev branch (`dev-pt`)