### PR TITLE
Modify a sentence in cloud native definition clearly

### DIFF
--- a/content/en/cloud_native_tech.md
+++ b/content/en/cloud_native_tech.md
@@ -6,7 +6,7 @@ category: Concept
 
 ## What it is
 
-Cloud native technologies, also referred to as the cloud native stack, are the technologies used to build [cloud native applications](/cloud_native_apps/). These technologiese enable organizations to build and run scalable applications in modern and dynamic environments such as public, private, and hybrid clouds, while leveraging [cloud computing](/cloud_computing/) benefits to their fullest. They are designed from the ground up to exploit the capabilities of cloud computing and containers, service meshes, microservices, and immutable infrastructure exemplify this approach.
+Cloud native technologies, also referred to as the cloud native stack, are the technologies used to build [cloud native applications](/cloud_native_apps/). These technologies enable organizations to build and run scalable applications in modern and dynamic environments such as public, private, and hybrid clouds, while leveraging [cloud computing](/cloud_computing/) benefits to their fullest. They are designed from the ground up to exploit the capabilities of cloud computing and containers, service meshes, microservices, and immutable infrastructure exemplify this approach.
 
 ## Problem it addresses 
 

--- a/content/en/cloud_native_tech.md
+++ b/content/en/cloud_native_tech.md
@@ -6,7 +6,7 @@ category: Concept
 
 ## What it is
 
-Cloud native technologies, also referred to as the cloud native stack, are the technologies used to build [cloud native applications](/cloud_native_apps/). Enabling organizations to build and run scalable applications in modern, dynamic environments such as public, private, and hybrid clouds, they uphold the ‘promise of the cloud’ and leverage cloud computing benefits to their fullest. They are designed from the ground up to exploit the capabilities of cloud computing and containers, service meshes, microservices, and immutable infrastructure exemplify this approach.
+Cloud native technologies, also referred to as the cloud native stack, are the technologies used to build [cloud native applications](/cloud_native_apps/). These technologiese enable organizations to build and run scalable applications in modern and dynamic environments such as public, private, and hybrid clouds, while leveraging [cloud computing](/cloud_computing/) benefits to their fullest. They are designed from the ground up to exploit the capabilities of cloud computing and containers, service meshes, microservices, and immutable infrastructure exemplify this approach.
 
 ## Problem it addresses 
 


### PR DESCRIPTION

This PR modifies a sentence in cloud native definition clearly.

I think people who search a definition for cloud native tech may not understand what is ‘promise of the cloud’.

So, I'd like to remove ‘promise of the cloud’ and refine the sentence.