### PR TITLE
Add zh l10n team approvers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -121,6 +121,19 @@ collaborators:
   - username: electrocucaracha
     permission: push
 
+  # l10n zh approvers
+  - username: hanyuancheung
+    permission: push
+
+  - username: Jacob953
+    permission: push
+
+  - username: Rocksnake
+    permission: push
+
+  - username: Submarinee
+    permission: push
+
 branches:
 
   # Default branch of this repository for configurations and English contents
@@ -288,6 +301,25 @@ branches:
          - CathPag
          - raelga
          - electrocucaracha
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for zh contents only
+  - name: dev-zh
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # zh approvers
+        users:
+         - hanyuancheung
+         - Jacob953
+         - Rocksnake
+         - Submarinee
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,3 +35,6 @@
 
 # Approvers for Spanish contents
 /content/es/ @CathPag @raelga @electrocucaracha
+
+# Approvers for Chinese contents
+/content/zh/ @hanyuancheung @Jacob953 @Rocksnake @Submarinee


### PR DESCRIPTION
Ref:
- [localization approvers](https://glossary.cncf.io/contributor-ladder/#localization-approvers)
- https://github.com/cncf/glossary/projects/2

---

- Add Chinese approver #451
  - [x] Chester Cheung (@hanyuancheung)
  - [x] Brian Yan (@Rocksnake)
  - [x] Jacob953 (@Jacob953)
  - [x] Submarinee (@Submarinee)

**[Important]**
 - All candidates need to **leave a comment** that you understood overall policy.
 - The l10n team approvers need to **use your permission appropriately**.
   - The approvers of l10n team will have a push permission to this repository.
It is to make l10n approvers manage (merge) PRs for l10n contributions in your development branch.
Merging a PR to the `main` branch by l10n approvers is restricted.
Even if they are possible to review a PR to the `main` branch and give an approval to the PR, they should not approve the PR. 
So, please do not approve if a PR is not related with your localization.
 - After this PR merged, the approvers will get an **github invitation** for collaborate from settings[bot] of cncf/glossary. You need to accept. 

---

**[PR merge condition to main branch]**
1. only chairs can merge PR to main branch 
2. at least one of codeowners should give approving review
   - codeowners for all files including English contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L6 (same as chairs)
3. at least 2 approving reviews are required from approvers.
4. l10n team approvers can give approving review to PR for any file. (but they should not)
   - Ref: https://github.com/cncf/glossary/pull/325#issuecomment-1015024262
   - but since they are not mean to be a reviewer or approver of English contents, we need to guide them not to approve PRs not related with their own l10n.
   - even though l10n team approvers give approving review, they CANNOT merge PR to main branch. it is restricted. (Like this: https://github.com/cncf/glossary/pull/325#issuecomment-1015026130)
   - We will probably have to evolve it over time. Anyway the main branch will be safe by the chairs

**[PR merge condition to dev-xx l10n branch (dev-ko)]**
1. chairs can merge PR to all branches (caniszczyk, jasonmorgan, CathPag, seokho-son)
2. at least one of l10n codeowners should give approving review
    - codeowners for Korean contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L13 (same as Korean approvers)
    - if a PR includes files outside of Koean l10n, chairs need to review and merge.
3. at least 2 approving reviews are required from l10n approvers.
4. l10n teams can merge PRs for their dev branch. If a PR includes files outside of l10n contents, They need to get an approval from maintainers (maintainers are codeowners for all files)

---

I hope to note that we are using the CODEOWNERS to automatically request a review to appropriate persons.
(https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about[…]owners)

The actual access permission can be configured from the repository setting (cncf/glossary repo).
- We can change access permission using Github UI. But we are using https://github.com/apps/settings App.
- https://github.com/apps/settings App syncs repository settings defined in https://github.com/cncf/glossary/blob/main/.github/settings.yml