### PR TITLE
Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CNCF Glossary contributing guide
 
-Thanks for your interest in contributing to the project. Contributions will be reflected on [glossary.cncf.io](https://glossary.cncf.io/) :sparkles: .
+Thanks for your interest in contributing to the project. Contributions will be reflected on [glossary.cncf.io](https://glossary.cncf.io/) :sparkles:
 
 Please read the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
@@ -11,4 +11,4 @@ Below are the guidelines for how to contribute to the code that runs the CNCF Gl
 1. **Report a bug**. If you see a technical issue with the CNCF Glossary site or something that doesn't look right, search [the existing issues](https://github.com/cncf/glossary/issues) to see if it has been reported already. If not, please [create a new issue](https://github.com/cncf/glossary/issues/new) describing the bug.
 2. **Fix a bug**. Find [an issue](https://github.com/cncf/glossary/issues) you want to fix and submit a PR for approval. 
 
-Read [more about the code that runs the Glossary site](https://github.com/cncf/glossary/blob/main/spin-new-glossary.md) and [how to set up your own local development instance](https://github.com/cncf/glossary#setting-up-a-local-instance). To connect with our community and ask questions, please join [this slack channel](https://cloud-native.slack.com/archives/C02TX20MQBB).
+Read [more about the code that runs the Glossary site](https://github.com/cncf/glossary/blob/main/spin-new-glossary.md) and [how to set up your own local development instance](https://github.com/cncf/glossary#setting-up-a-local-instance). To connect with our community and ask questions, please join [the #glossary channel on the CNCF slack](https://cloud-native.slack.com/archives/C02TX20MQBB).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to the project. Contributions will be r
 
 Please read the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
-Below are the guidelines for how to contribute to the code that runs the CNCF Glossary website. For guidlines on contributing to the content of the Glossary itself, however, please see [How to Contribute](https://glossary.cncf.io/contribute/).
+Below are the guidelines for how to contribute to the code that runs the CNCF Glossary website. For guidelines on contributing to the content of the Glossary itself, however, please see [How to Contribute](https://glossary.cncf.io/contribute/).
 
 ## How can I contribute?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# CNCF Glossary contributing guide
+
+Thanks for your interest in contributing to the project. Contributions will be reflected on [glossary.cncf.io](https://glossary.cncf.io/) :sparkles: .
+
+Please read the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+Below are the guidelines for how to contribute to the code that runs the CNCF Glossary website. For guidlines on contributing to the content of the Glossary itself, however, please see [How to Contribute](https://glossary.cncf.io/contribute/).
+
+## How can I contribute?
+
+1. **Report a bug**. If you see a technical issue with the CNCF Glossary site or something that doesn't look right, search [the existing issues](https://github.com/cncf/glossary/issues) to see if it has been reported already. If not, please [create a new issue](https://github.com/cncf/glossary/issues/new) describing the bug.
+2. **Fix a bug**. Find [an issue](https://github.com/cncf/glossary/issues) you want to fix and submit a PR for approval. 
+
+Read [more about the code that runs the Glossary site](https://github.com/cncf/glossary/blob/main/spin-new-glossary.md) and [how to set up your own local development instance](https://github.com/cncf/glossary#setting-up-a-local-instance). To connect with our community and ask questions, please join [this slack channel](https://cloud-native.slack.com/archives/C02TX20MQBB).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Below are the guidelines for how to contribute to the code that runs the CNCF Gl
 
 ## How can I contribute?
 
-1. **Report a bug**. If you see a technical issue with the CNCF Glossary site or something that doesn't look right, search [the existing issues](https://github.com/cncf/glossary/issues) to see if it has been reported already. If not, please [create a new issue](https://github.com/cncf/glossary/issues/new) describing the bug.
+1. **Report a bug**. If you see a technical issue with the CNCF Glossary site or something that doesn't look right, search [the existing issues](https://github.com/cncf/glossary/issues) to see if it has been reported already. If not, please [create a new issue](https://github.com/cncf/glossary/issues/new) describing the bug. Please provide all steps necessary to reproduce the bug and screenshots if applicable.
 2. **Fix a bug**. Find [an issue](https://github.com/cncf/glossary/issues) you want to fix and submit a PR for approval. 
 
 Read [more about the code that runs the Glossary site](https://github.com/cncf/glossary/blob/main/spin-new-glossary.md) and [how to set up your own local development instance](https://github.com/cncf/glossary#setting-up-a-local-instance). To connect with our community and ask questions, please join [the #glossary channel on the CNCF slack](https://cloud-native.slack.com/archives/C02TX20MQBB).


### PR DESCRIPTION
You can [view the guide here](https://github.com/cncf/glossary/blob/contribute/CONTRIBUTING.md). This adds the standard GitHub Contributing guide to the repo. It's mainly meant to guide anyone looking to improve the code of the Glossary. This is different than [our instructions here on how to contribute to the Glossary content](https://glossary.cncf.io/contribute/). Closes #425.