### PR TITLE
Update issue template for new term proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-term.yml
+++ b/.github/ISSUE_TEMPLATE/new-term.yml
@@ -15,7 +15,7 @@ body:
   - type: textarea
     id: details
     attributes:
-      label: Please describe why this term needs to be added
+      label: 1. Please describe why this term needs to be added
       value: |
         #### What this term is about? (briefly)
         - 
@@ -26,7 +26,7 @@ body:
   - type: checkboxes
     id: checkboxes
     attributes:
-      label: Checklist
+      label: 2. Checklist
       options:
         - label: There is no existing issue yet. [(shift+click to check existing issues)](https://github.com/cncf/glossary/issues?q=label%3A%22new+term%22)
           required: true
@@ -34,12 +34,11 @@ body:
           required: true
         - label: I want to work on this term. (If you don't check, maintainers will assign another volunteer)
           required: false
-  - type: markdown
+  - type: textarea
+    id: note
     attributes:
+      label: (Note)
       value: |
-        ---
-        ## Note
-        
         Maintainers will assign a label after assessment procedure. 
         (from `triage/awaiting` to `triage/accepted` or `triage/not accepted`)
 

--- a/.github/ISSUE_TEMPLATE/new-term.yml
+++ b/.github/ISSUE_TEMPLATE/new-term.yml
@@ -1,8 +1,17 @@
-name: Request to add a new term (Default:English)
+name: Request to add a new term (English)
 description: Issue to add a new term in English
-title: "[New term] `GlossaryTermHere` for `En`"
-labels: ["lang/en","new term"]
+title: "[New term] `GlossaryTermHere`"
+labels: ["lang/en","new term","triage/awaiting"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Thanks for taking the time to add a request to the glossary!
+        
+        This issue-template is to propose a new Glossary term.
+        Please check https://glossary.cncf.io/contribute/#propose-new-terms first.
+
   - type: textarea
     id: details
     attributes:
@@ -14,11 +23,25 @@ body:
         - 
     validations:
       required: true
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Checklist
+      options:
+        - label: There is no existing issue yet. [(shift+click to check existing issues)](https://github.com/cncf/glossary/issues?q=label%3A%22new+term%22)
+          required: true
+        - label: I understand that maintainers will assess if the term should be part of the Glossary. (Please be patient)
+          required: true
+        - label: I want to work on this term. (If you don't check, maintainers will assign another volunteer)
+          required: false
   - type: markdown
     attributes:
       value: |
         ---
-        ## Thanks for taking the time to add a request to the glossary!
-        To claim this issue, please ask for it below. 
-        The maintainers will assign a contributor to this issue.
-        Before getting started, please refer to the [style guide](https://glossary.cncf.io/style-guide/).
+        ## Note
+        
+        Maintainers will assign a label after assessment procedure. 
+        (from `triage/awaiting` to `triage/accepted` or `triage/not accepted`)
+
+        A contributor can be assigned to this issue after the issue get the `triage/accepted` label.
+        The assignee needs to check [Style Guide](https://glossary.cncf.io/style-guide/).

--- a/.github/ISSUE_TEMPLATE/new-term.yml
+++ b/.github/ISSUE_TEMPLATE/new-term.yml
@@ -32,7 +32,7 @@ body:
           required: true
         - label: I understand that maintainers will assess if the term should be part of the Glossary. (Please be patient)
           required: true
-        - label: I want to work on this term. (If you don't check, maintainers will assign another volunteer)
+        - label: I want to work on this term. (If not checked, maintainers will assign another volunteer)
           required: false
   - type: textarea
     id: note


### PR DESCRIPTION
This PR enhances the existing issue template for a new term proposal.

with following enhancements
 - auto-labeling : lang/en, new term, `triage/awaiting`
 - explain triage procedure (assessment for new term proposal)
 - checklist

### link to test the issue template

https://github.com/seokho-son/glossary/issues/new?assignees=&labels=lang%2Fen%2Cnew+term%2Ctriage%2Fawaiting&template=new-term.yml&title=%5BNew+term%5D+%60GlossaryTermHere%60


### an opened issue example 

https://github.com/seokho-son/glossary/issues/17


![image](https://user-images.githubusercontent.com/5966944/157440271-36e32671-f9c9-4696-a6b5-576938e3c382.png)
