### PR TITLE
Add Carol Valencia to Spanish approver team

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -124,6 +124,9 @@ collaborators:
   - username: electrocucaracha
     permission: push
 
+  - username: krol3
+    permission: push
+
   # l10n zh approvers
   - username: hanyuancheung
     permission: push
@@ -304,6 +307,7 @@ branches:
          - CathPag
          - raelga
          - electrocucaracha
+         - krol3
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,7 +34,7 @@
 /content/bn/ @mitul3737 @Mouly22 @ikramulkayes
 
 # Approvers for Spanish contents
-/content/es/ @CathPag @raelga @electrocucaracha
+/content/es/ @CathPag @raelga @electrocucaracha @krol3
 
 # Approvers for Chinese contents
 /content/zh/ @hanyuancheung @Jacob953 @Rocksnake @Submarinee


### PR DESCRIPTION
Given her active [collaboration](https://github.com/cncf/glossary/issues?q=label%3Alang%2Fes+is%3Aclosed+author%3Akrol3) in Spanish localization team, this PR recognizes the effort made by @krol3 and promotes her with the approver role.

/cc @raelga 