### PR TITLE
Update localization team approvers (dev-ar, dev-es)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -117,11 +117,13 @@ collaborators:
     permission: push
 
   # l10n es approvers
-  # Note: CathPag is both a maintainer (maintain) and de approver (push)
   - username: raelga
     permission: push
     
   - username: electrocucaracha
+    permission: push
+
+  - username: krol3
     permission: push
 
   # l10n zh approvers
@@ -301,9 +303,9 @@ branches:
         apps: []
         # es approvers
         users:
-         - CathPag
          - raelga
          - electrocucaracha
+         - krol3
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -97,13 +97,13 @@ collaborators:
   - username: TarekMSayed
     permission: push
 
-  - username: arezk84
+  - username: same7ammar
     permission: push
 
   - username: AShabana
     permission: push
 
-  - username: hacktron95
+  - username: arezk84
     permission: push
 
   # l10n bn approvers
@@ -267,9 +267,9 @@ branches:
         # ar approvers
         users:
          - TarekMSayed
-         - arezk84
+         - same7ammar
          - AShabana
-         - hacktron95
+         - arezk84
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -97,7 +97,7 @@ collaborators:
   - username: TarekMSayed
     permission: push
 
-  - username: same7ammar
+  - username: arezk84
     permission: push
 
   - username: AShabana
@@ -265,7 +265,7 @@ branches:
         # ar approvers
         users:
          - TarekMSayed
-         - same7ammar
+         - arezk84
          - AShabana
          - hacktron95
         teams: []

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@
 /content/it/ @fsbaraglia @meryem-ldn @annalisag-spark @sistella
 
 # Approvers for Arabic contents
-/content/ar/ @TarekMSayed @arezk84 @AShabana @hacktron95
+/content/ar/ @TarekMSayed @same7ammar @AShabana @arezk84
 
 # Approvers for Bengali contents
 /content/bn/ @mitul3737 @Mouly22 @ikramulkayes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@
 /content/it/ @fsbaraglia @meryem-ldn @annalisag-spark @sistella
 
 # Approvers for Arabic contents
-/content/ar/ @TarekMSayed @same7ammar @AShabana @hacktron95
+/content/ar/ @TarekMSayed @arezk84 @AShabana @hacktron95
 
 # Approvers for Bengali contents
 /content/bn/ @mitul3737 @Mouly22 @ikramulkayes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,7 +34,7 @@
 /content/bn/ @mitul3737 @Mouly22 @ikramulkayes
 
 # Approvers for Spanish contents
-/content/es/ @CathPag @raelga @electrocucaracha
+/content/es/ @raelga @electrocucaracha @krol3
 
 # Approvers for Chinese contents
 /content/zh/ @hanyuancheung @Jacob953 @Rocksnake @Submarinee


### PR DESCRIPTION
Based on requests from l10n teams, I added [localization approvers](https://glossary.cncf.io/contributor-ladder/#localization-approvers) for each language.
(https://github.com/cncf/glossary/projects/2)


- Update Arabic approvers
  - (invite) Ahmed Rezk (@arezk84)
  - (release) Osama Nabil (@hacktron95)
  
- Update Spanish approvers
  - (invite) Carol Valencia (@krol3)
  - (release from dev-es) Catherine Paganini (@CathPag) 

**[Important]**
 - All candidates need to **leave a comment** that you understood overall policy. (l10n teams: please share this message to candidates)
 - The l10n team approvers need to **use your permission appropriately**.
   - The approvers of l10n team will have a push permission to this repository.
It is to make l10n approvers manage (merge) PRs for l10n contributions in your development branch.
Merging a PR to the `main` branch by l10n approvers is restricted.
Even if they are possible to review a PR to the `main` branch and give an approval to the PR, they should not approve the PR. 
So, please do not approve if a PR is not related with your localization.
 - After this PR merged, the approvers will get an **github invitation** for collaborate from settings[bot] of cncf/glossary. You need to accept. 

---


**[PR merge condition to main branch]**
1. only chairs can merge PR to main branch 
2. at least one of codeowners should give approving review
   - codeowners for all files including English contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L6 (same as chairs)
3. at least 2 approving reviews are required from approvers.
4. l10n team approvers can give approving review to PR for any file. (but they should not)
   - Ref: https://github.com/cncf/glossary/pull/325#issuecomment-1015024262
   - but since they are not mean to be a reviewer or approver of English contents, we need to guide them not to approve PRs not related with their own l10n.
   - even though l10n team approvers give approving review, they CANNOT merge PR to main branch. it is restricted. (Like this: https://github.com/cncf/glossary/pull/325#issuecomment-1015026130)
   - We will probably have to evolve it over time. Anyway the main branch will be safe by the chairs

**[PR merge condition to dev-xx l10n branch (dev-ko)]**
1. chairs can merge PR to all branches (caniszczyk, jasonmorgan, CathPag, seokho-son)
2. at least one of l10n codeowners should give approving review
    - codeowners for Korean contents: https://github.com/cncf/glossary/blob/main/CODEOWNERS#L13 (same as Korean approvers)
    - if a PR includes files outside of Koean l10n, chairs need to review and merge.
3. at least 2 approving reviews are required from l10n approvers.
4. l10n teams can merge PRs for their dev branch. If a PR includes files outside of l10n contents, They need to get an approval from maintainers (maintainers are codeowners for all files)

---

I hope to note that we are using the CODEOWNERS to automatically request a review to appropriate persons.
(https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about[…]owners)

The actual access permission can be configured from the repository setting (cncf/glossary repo).
- We can change access permission using Github UI. But we are using https://github.com/apps/settings App.
- https://github.com/apps/settings App syncs repository settihngs defined in https://github.com/cncf/glossary/blob/main/.github/settings.yml