### PR TITLE
[en] Add term: 'Event-Driven Architecture'

### DIFF
--- a/content/en/event-driven-architecture.md
+++ b/content/en/event-driven-architecture.md
@@ -8,18 +8,18 @@ category: concept
 
 Event-driven architecture is a software architecture that promotes the creation, processing, and consumption of events.
 An event is any change to an application's state.
-For example, hailing a ride on a ride sharing app represents an event.
-This architecture creates the structure in which events can be properly routed from their source (my app requesting that ride) to the desired receivers (the apps of available drivers nearby).
+For example, hailing a ride on a ride-sharing app represents an event.
+This architecture creates the structure in which events can be properly routed from their source (the app requesting a ride) to the desired receivers (the apps of available drivers nearby).
 
 ## Problem it addresses
 
 As more data becomes real-time, finding reliable ways to ensure that events are captured and routed to the appropriate [service](/service/) that must process event requests gets increasingly challenging.
-Traditional methods of handling events often have no way to guarantee that messages were being routed properly or were actually sent or received.
+Traditional methods of handling events often have no way to guarantee that messages are appropriately routed or were actually sent or received.
 As applications begin to scale, it becomes more challenging to orchestrate events.
 
 ## How it helps
 
-Event-driven architectures establishes a central hub for all events (e.g. Kafka).
-You then define the event producers (source) and consumers (receiver) and the central event hub guarantees the flow of events.
+Event-driven architectures establish a central hub for all events (e.g., Kafka).
+You then define the event producers (source) and consumers (receiver), and the central event hub guarantees the flow of events.
 This architecture ensures that services remain decoupled and events are properly routed from the producer to the consumer.
 The producer will take the incoming event, usually by HTTP protocol, then route the event information.

--- a/content/en/event-driven-architecture.md
+++ b/content/en/event-driven-architecture.md
@@ -1,0 +1,25 @@
+---
+title: Event-Driven Architecture
+status: Completed
+category: concept
+---
+
+## What it is
+
+Event-driven architecture is a software architecture that promotes the creation, processing, and consumption of events.
+An event is any change to an application's state.
+For example, hailing a ride on a ride sharing app represents an event.
+This architecture creates the structure in which events can be properly routed from their source (my app requesting that ride) to the desired receivers (the apps of available drivers nearby).
+
+## Problem it addresses
+
+As more data becomes real-time, finding reliable ways to ensure that events are captured and routed to the appropriate [service](/service/) that must process event requests gets increasingly challenging.
+Traditional methods of handling events often have no way to guarantee that messages were being routed properly or were actually sent or received.
+As applications begin to scale, it becomes more challenging to orchestrate events.
+
+## How it helps
+
+Event-driven architectures establishes a central hub for all events (e.g. Kafka).
+You then define the event producers (source) and consumers (receiver) and the central event hub guarantees the flow of events.
+This architecture ensures that services remain decoupled and events are properly routed from the producer to the consumer.
+The producer will take the incoming event, usually by HTTP protocol, then route the event information.


### PR DESCRIPTION
- This PR supersedes & closes #637.
  - [Removed irrelevant commits.](https://github.com/cncf/glossary/pull/637#issuecomment-1152419574)
  - Squashed 3 commits from @jasonsmithio to one single commit.
  - [Added missing line.](https://github.com/cncf/glossary/pull/637/files#r894446870)
  - [Renamed to `event-driven-architecture.md`.](https://github.com/cncf/glossary/pull/637/files#r894456454)
  - Removed hard-coded domain name. (`https://glossary.cncf.io/service/` → `/service/`)
