### PR TITLE
Add `.hugo_build.lock` file to `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 public/
 resources/
 node_modules/
+.hugo_build.lock


### PR DESCRIPTION
This PR adds `.hugo_build.lock` file to `gitignore`,
which will prevent cases like https://github.com/cncf/glossary/pull/997#issuecomment-1166452462.