### PR TITLE
Get Search working on PR instance

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://glossary.cncf.io/"
+baseURL = "/"
 title = "Cloud Native Glossary"
 
 enableRobotsTXT = true


### PR DESCRIPTION
Currently the search form on PR instance redirects to the live Glossary site. This PR is to get it so that the form keeps the user on current instance.

If you go to [this dev instance](https://deploy-preview-1050--cncfglossary.netlify.app/) and search for something, you'll see the search results now appear on the same dev instance rather than going to the live site.

Signed-off-by: cjyabraham <cjyabraham@gmail.com>