### PR TITLE
[ptbr] Translate i18n strings used in tags

### DIFF
--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -18,7 +18,9 @@ other = "em"
 
 # Used in sentences such as "All Tags"
 [ui_all]
-other = "todos"
+other = "todas"
+[ui_see_all]
+other = "Ver todas"
 
 # Footer text
 [footer_all_rights_reserved]


### PR DESCRIPTION
Signed-off-by: Ana Cunha <1771610+anacunha@users.noreply.github.com>

[Portuguese] Translate i18n strings to use tags #1048 

Changed translation from `"todos"` to `"todas"` as it is meant to be used in sentences such as `"All Tags"`, which translates better to `"Todas Tags"`