### PR TITLE
Settings and initial contents for French localization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -120,7 +120,7 @@ weight = 8
 [languages.fr]
 title = "Glossaire Cloud Native"
 description = "Le projet de Glossaire CNCF Cloud Natif a pour objectif de référencer les termes courants utilisés dans les différentes applications cloud native."
-languageName ="Français (French)"
+languageName ="Français(French)"
 contentDir = "content/fr"
 weight = 9
 

--- a/config.toml
+++ b/config.toml
@@ -117,6 +117,13 @@ languageName = "বাংলা(Bengali)"
 contentDir = "content/bn"
 weight = 8
 
+[languages.fr]
+title = "Glossaire Cloud Native"
+description = "Le projet Glossaire de la CNCF Cloud Native a pour objectif de référencer les termes courants utilisés dans les différentes applications cloud native."
+languageName ="Français (French)"
+# Weight used for sorting.
+weight = 9
+
 
 [markup]
   [markup.goldmark]

--- a/config.toml
+++ b/config.toml
@@ -119,9 +119,9 @@ weight = 8
 
 [languages.fr]
 title = "Glossaire Cloud Native"
-description = "Le projet Glossaire de la CNCF Cloud Native a pour objectif de référencer les termes courants utilisés dans les différentes applications cloud native."
+description = "Le projet de Glossaire CNCF Cloud Natif a pour objectif de référencer les termes courants utilisés dans les différentes applications cloud native."
 languageName ="Français (French)"
-# Weight used for sorting.
+contentDir = "content/fr"
 weight = 9
 
 

--- a/content/fr/_TEMPLATE.md
+++ b/content/fr/_TEMPLATE.md
@@ -1,0 +1,22 @@
+---
+title: Modèle de définition
+status: Feedback Appreciated
+category: concept
+---
+
+
+## Ce que c'est
+
+Un bref descriptif de la technologie ou du concept.
+
+## Problème qu'il adresse
+
+Quelques lignes à propos du problème qu'il adresse.
+
+## Quel en est l'utilité
+
+Quelques lignes sur comment le problème est résolu.
+
+## Termes liés
+
+Ajouter les termes du Glossaire en relation (si applicable)

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -11,7 +11,7 @@ Son rôle est d'expliquer les concepts cloud natifs en termes simples et clairs,
 
 ## Contribution
 
-Toute personne est invitée a suggérer des changements, des ajouts, ou des amélioration au Glossaire Cloud Natif.
+Toute personne est invitée à suggérer des changements, des ajouts, ou des amélioration au Glossaire Cloud Natif.
 Nous employons un processus dirigé par la communauté, et gouverné par la CNCF, afin de développer et d'améliorer ce lexique partagé.
 Ce Glossaire fournit un plateforme indépendante de toute solution propriétaire, afin d'organiser un vocabulaire partagé par tous, le tout centré autour des technologies cloud natives.
 Les contributions sont les bienvenues pour tous les participants adhérant au principe du projet, ainsi qu'à sa charte.

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -14,7 +14,7 @@ Son rôle est d'expliquer les concepts cloud natifs en termes simples et clairs,
 Toute personne est invitée a suggérer des changements, des ajouts, ou des amélioration au Glossaire Cloud Natif.
 Nous employons un processus dirigé par la communauté, et gouverné par la CNCF, afin de développer et d'améliorer ce lexique partagé.
 Ce Glossaire fournit un plateforme indépendante de toute solution propriétaire, afin d'organiser un vocabulaire partagé par tous, le tout centré autour des technologies cloud natives.
-Les contributions sont les bienvenues pour tous les participants adérants au principe du projet, ainsi qu'à sa charte.
+Les contributions sont les bienvenues pour tous les participants adhérant au principe du projet, ainsi qu'à sa charte.
 
 Toute personne souhaitant faire une contribution peut soumettre une Issue ou ouvrir une Pull Request sur le dépôt GitHub.
 S'assurer avant tout de suivre le [Guide de Rédaction](/style-guide/), de lire la [Documentation de contribution](/contribute/), ainsi que de rejoindre le canal [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) du Slack de la CNCF.

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Glossaire Cloud Natif"
+---
+
+# Glossaire Cloud Natif
+
+Le Glossaire Cloud Native est un project dirigé par le Sous-comité de Valeur Commerciale de la CNCF (Business Value Subcommittee, BVS).
+Son rôle est d'expliquer les concepts cloud natifs en termes simples et clairs, et sans nécessité de connaissances techniques.
+
+<p><img class="mt-5" src="/images/homepage/stage.jpg" alt="Une femme et deux hommes en présentation technique"></p>
+
+## Contributing
+
+Toute personne est invitée a suggérer des changements, des ajouts, ou des amélioration au Glossaire Cloud Natif.
+Nous employons un processus dirigé par la communauté, et gouverné par la CNCF, afin de développer et d'améliorer ce lexique partagé.
+Ce Glossaire fournit un plateforme indépendante des solutions propriétaires, afin d'organiser un vocabulaire partagé par tous, le tout centré autour des technologies cloud natives.
+Les contributions sont les bienvenues pour tous les participants adérants au principe du projet ainsi qu'à sa charte.
+
+Toute personne souhaitant faire une contribution peut soumettre une Issue ou créer une Pull Request sur le dépôt GitHub.
+S'assurer avant tout de suivre le [Style Guide](/style-guide/), de lire la [Documentation de contribution](/contribute/), ainsi que de rejoindre le canal [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) du Slack de la CNCF.
+Il existe également un canal [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) pour ceux qui souhaitent aider à la traduction du glossaire dans leur langage natif.
+
+## Remerciements
+
+Le Glossaire Cloud Natif a été initié par le Comité Marketing de la CNCF (Business Value Subcommittee) et inclue les contributions de
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), 
+[Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/), 
+[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk), 
+[Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), 
+[Katelin Ramer](https://www.linkedin.com/in/katelinramer/), 
+[Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca), 
+et bien d'autres contributeurs.
+Pour la liste complète des contributeurs, se référer a la [Page GitHub](https://github.com/cncf/glossary/graphs/contributors).
+
+Ce Glossaire est maintenue par
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), 
+[Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), 
+[Jihoon Seo](https://www.linkedin.com/in/jihoon-seo/), 
+[Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/), 
+et [Seokho Son](https://www.linkedin.com/in/seokho-son/).
+
+## Licence
+
+Toute contribution de code est sous licence Apache 2.0.
+La documentation est distribuée sous CC BY 4.0.

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -4,20 +4,20 @@ title: "Glossaire Cloud Natif"
 
 # Glossaire Cloud Natif
 
-Le Glossaire Cloud Native est un project dirigé par le Sous-comité de Valeur Commerciale de la CNCF (Business Value Subcommittee, BVS).
+Le Glossaire Cloud Natif est un project dirigé par le Comité Marketing de la CNCF (Business Value Subcommittee, BVS).
 Son rôle est d'expliquer les concepts cloud natifs en termes simples et clairs, et sans nécessité de connaissances techniques.
 
 <p><img class="mt-5" src="/images/homepage/stage.jpg" alt="Une femme et deux hommes en présentation technique"></p>
 
-## Contributing
+## Contribution
 
 Toute personne est invitée a suggérer des changements, des ajouts, ou des amélioration au Glossaire Cloud Natif.
 Nous employons un processus dirigé par la communauté, et gouverné par la CNCF, afin de développer et d'améliorer ce lexique partagé.
-Ce Glossaire fournit un plateforme indépendante des solutions propriétaires, afin d'organiser un vocabulaire partagé par tous, le tout centré autour des technologies cloud natives.
-Les contributions sont les bienvenues pour tous les participants adérants au principe du projet ainsi qu'à sa charte.
+Ce Glossaire fournit un plateforme indépendante de toute solution propriétaire, afin d'organiser un vocabulaire partagé par tous, le tout centré autour des technologies cloud natives.
+Les contributions sont les bienvenues pour tous les participants adérants au principe du projet, ainsi qu'à sa charte.
 
-Toute personne souhaitant faire une contribution peut soumettre une Issue ou créer une Pull Request sur le dépôt GitHub.
-S'assurer avant tout de suivre le [Style Guide](/style-guide/), de lire la [Documentation de contribution](/contribute/), ainsi que de rejoindre le canal [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) du Slack de la CNCF.
+Toute personne souhaitant faire une contribution peut soumettre une Issue ou ouvrir une Pull Request sur le dépôt GitHub.
+S'assurer avant tout de suivre le [Guide de Rédaction](/style-guide/), de lire la [Documentation de contribution](/contribute/), ainsi que de rejoindre le canal [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) du Slack de la CNCF.
 Il existe également un canal [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) pour ceux qui souhaitent aider à la traduction du glossaire dans leur langage natif.
 
 ## Remerciements
@@ -30,7 +30,7 @@ Le Glossaire Cloud Natif a été initié par le Comité Marketing de la CNCF (Bu
 [Katelin Ramer](https://www.linkedin.com/in/katelinramer/), 
 [Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca), 
 et bien d'autres contributeurs.
-Pour la liste complète des contributeurs, se référer a la [Page GitHub](https://github.com/cncf/glossary/graphs/contributors).
+Pour la liste complète des contributeurs, se référer à la [Page GitHub](https://github.com/cncf/glossary/graphs/contributors).
 
 Ce Glossaire est maintenue par
 [Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), 

--- a/content/fr/contribute/_index.md
+++ b/content/fr/contribute/_index.md
@@ -41,7 +41,7 @@ Une fois que vous avez trouvé le terme sur lequel vous voulez travailler, dites
 
 ![S'assigner une issue](/images/how-to/claiming-an-issue.png)
 
-Additionellement, merci de rejoindre le channel Slack [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) et de faire savoir aux mainteneurs que vous avez créé une issue pour un terme (idéalement, en mentionnant, _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, et/ou _@iamnoah_ pour être sûr qu'il ne passe pas à côté).
+Additionnellement, merci de rejoindre le channel Slack [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) et de faire savoir aux mainteneurs que vous avez créé une issue pour un terme (idéalement, en mentionnant, _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, et/ou _@iamnoah_ pour être sûr qu'il ne passe pas à côté).
 
 Vous pouvez uniquement proposer un terme à la fois.
 
@@ -79,8 +79,8 @@ Si vous souhaitez juste proposer un nouveau terme, vous pouvez vous arrêter là
 
 ### Catégoriser votre issue {#triaging-your-issue}
 
-Ensuite, les mainteneurs vont trier le ticket
-Cela veut dire qu'ils vont évaluer si votre terme peut être présent dans le glossaire (Il est à noter, que tous les termes ne sont pas admis. Les termes doivent faire partie des termes couramment utilisés dans l'eco-système Cloud Native).
+Ensuite, les mainteneurs vont catégoriser le ticket.
+Cela veut dire qu'ils vont évaluer si votre terme peut être présent dans le glossaire (Il est à noter, que tous les termes ne sont pas admis. Les termes doivent faire partie des termes couramment utilisés dans l'écosystème Cloud Native).
 
 Merci de faire savoir aux mainteneurs que vous avez soumis un terme sur Slack, sinon il pourrait passer à côté.
 Idéalement, mentionnez _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, and/or _@iamnoah_. 
@@ -117,7 +117,7 @@ Une fois que le terme est prêt à être proposé, rédigez le contenu (sous for
 
 ![create new file](/images/how-to/howto-09.png)
 
-Ajouter le terme dans l'url (pas de majuscules, pas d'espaces, pas de parenthèses et utiliser un tirer pour séparer les mots) rajouter .md à la fin du nom de votre fichier (note: Si la prévisualisation ne fonctionne pas, vous avez probablement oublié d'ajouter .md à la fin).
+Ajouter le terme dans l'url (pas de majuscules, pas d'espaces, pas de parenthèses et utiliser un tiret pour séparer les mots) rajouter .md à la fin du nom de votre fichier (note: Si la prévisualisation ne fonctionne pas, vous avez probablement oublié d'ajouter .md à la fin).
 Maintenant copier le contenu. Copier et coller votre définition dans le fichier.
 Pour faciliter les relectures, merci **d'utiliser [semantic line breaks](https://sembr.org/)** (e.g. une ligne par phrase).
 

--- a/content/fr/contribute/_index.md
+++ b/content/fr/contribute/_index.md
@@ -1,0 +1,169 @@
+---
+title: How To Contribute
+toc_hide: true
+menu:
+  main:
+    weight: 10
+---
+
+The Cloud Native Glossary content is stored in [this GitHub repo](https://github.com/cncf/glossary) 
+where you'll find a list of [issues](https://github.com/cncf/glossary/issues), [PRs](https://github.com/cncf/glossary/pulls), and 
+[discussions](https://github.com/cncf/glossary/discussions) about the glossary. 
+
+There are four ways you can contribute:
+
+1) [Work on an existing issue](#work-on-an-existing-issue)
+2) [Propose new terms](#propose-new-terms)
+3) [Update existing ones](#update-an-existing-term)
+4) [Help translate the glossary](#help-translate-the-glossary)
+
+## Join the Glossary community! {#join-the-glossary-community}
+
+Consider joining our monthly Glossary Working Group meetings if you want to contribute regularly. 
+You can find meeting details in the [CNCF calendar](https://www.cncf.io/calendar/). 
+You can also connect with the maintainers and fellow contributors in our [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel on the CNCF Slack 
+— we'd love to meet you! 
+
+## Work on an existing issue {#work-on-an-existing-issue}
+
+Go to the [Glossary GitHub repo issues](https://github.com/cncf/glossary/issues). 
+There you'll see a list of all issues. You can filter by label (e.g. English language, help needed, good first issue). 
+Note that you'll need a GitHub account to do any of this.
+
+![Issue and labels](/images/how-to/issue-and-labels.png)
+
+Make sure the term you are interested in is not already assigned to someone. 
+Here you can see that the first three terms are available while the next term has already been assigned.
+
+![assigning a term](/images/how-to/howto-04.png)
+
+Once you found a term you want to work on, say so in the issue. Click on it and add a comment.
+
+![Claiming an issue](/images/how-to/claiming-an-issue.png)
+
+Additionally, please also join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel on the CNCF Slack and 
+let the maintainers know that you've raised an issue for a new term 
+(ideally, tag _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, and/or _@iamnoah_ to be sure they don't miss it). 
+Note that you can only claim one term at a time. 
+If you want to work on multiple terms, please finish one before claiming the next one.
+
+Once they assign it to you, you can start working on it. 
+For the next steps, please refer to the [Submitting a new term (creating a PR)](#submitting-a-new-term) section.
+
+## Propose new terms {#propose-new-terms}
+
+You can propose a new term for others to work on or create a new definition yourself. 
+Either way, you'll start by creating an issue. 
+Please note that terms must meet the [CNCF's cloud native definition](https://github.com/cncf/toc/blob/main/DEFINITION.md). 
+The only exceptions are foundational terms needed to understand cloud native concepts.
+
+Below is a step-by-step guide for those not yet familiar with GitHub. 
+**If you are a GitHub Pro**, please _do_ have a quick look to make sure you use our issue templates, 
+appropriate naming conventions, claim a PR on Slack (otherwise we may miss it), and where to find the file template. 
+And please make sure to read the [Style Guide](/style-guide/) before getting started — thank you! 
+
+### Creating an issue {#creating-an-issue}
+
+Go to the [Glossary GitHub repo](https://github.com/cncf/glossary/issues) issues and click on "New issue".
+
+![issues](/images/how-to/howto-01.png)
+
+You'll see a variety of templates. To propose a new term in English, select "Request to add a new term (English)".
+
+![templates](/images/how-to/english-issue-template.jpg)
+
+Add the word you're suggesting, answer the two questions below, check the checkboxes, and hit "Submit new issue".
+If you're just proposing a new term, you're done! To work on it, follow the next steps.
+
+### Triaging your issue {#triaging-your-issue}
+
+Next, the maintainers will triage the issue. 
+That means they will assess if the term should be part of the Glossary 
+(note, not every term will be admitted. Terms should be established and widely-used cloud native terms).
+
+Please let the maintainers know that you've submitted a term on Slack as they may otherwise miss it. 
+Ideally, tag _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, and/or _@iamnoah_. 
+If the term is approved and you want to work on it, they'll assign it to you.
+
+Note that you can only claim one term at a time. 
+If you want to work on multiple terms, please finish one before claiming the next.
+
+### Submitting a new term (creating a PR) {#submitting-a-new-term}
+
+Before getting started, please read the [Style Guide](/style-guide/) — it will help minimize backs and forth. 
+As stated in the style guide, we highly recommend starting with a Google or Word doc. 
+
+Once the term is ready to submit, go to content (under code)…
+
+![content](/images/how-to/howto-05.png)
+
+…then "en" (or the language you are submitting for)…
+
+![language folder](/images/how-to/howto-06.png)
+
+…and select `_TEMPLATE.md`
+
+![template](/images/how-to/howto-07.png)
+
+Copy the content…
+
+![copy content](/images/how-to/howto-08.png)
+
+…and go back to the "en" folder. Hit "Add file" and select "Create new file".
+
+![create new file](/images/how-to/howto-09.png)
+
+Add the term name in the URL (no capitalization, no spaces, no parentheses, and use hyphens to separate words)
+and .md at the end (note: if your preview doesn't work, you probably forgot to add .md at the end).
+Now paste the template content below. Copy and paste your definition into the file.
+To make reviews easier, please **use [semantic line breaks](https://sembr.org/)** (e.g. one line per sentence).
+Note that GitHub uses markdown to format the text (e.g., hyperlink, bold, italic).
+Please refer to this [markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/).
+To verify you've used markdown as intended, go to "Preview".
+
+![finalize term](/images/how-to/howto-10.png)
+
+Scroll down and name the new commit file when you are ready to submit. 
+You are now about to commit the term to your own branch. 
+Submitting a PR requires one more step. Hit "Commit new file" and…
+
+![commit new file](/images/how-to/howto-11.png)
+
+…now you're creating an PR:
+
+![create a pr](/images/how-to/howto-12.png)
+
+You should now see your PR under "Pull requests".
+
+![prs](/images/how-to/howto-13.png)
+
+## Update an existing term {#update-an-existing-term}
+
+To update an existing term, you can either suggest a change via an issue or go ahead and update the term directly by submitting a pull request (PR).
+
+### Request a change via an issue {#request-a-change-via-an-issue}
+
+If you want to flag a problem with a term but don't know how or want to fix it yourself, click on "Report issue".
+
+![report issue](/images/how-to/howto-14.png)
+
+This will directly open an issue. Please elaborate on which change is needed and why. Hit submit, and that's it. 
+
+![submit issue](/images/how-to/howto-15.png)
+
+### Update a term directly {#update-a-term-directly}
+
+To change a term directly, go to "Edit this page".
+
+![edit this page](/images/how-to/howto-16.png)
+
+This will open the term's GitHub page. Make your changes and submit a PR. 
+Please refer to "Submitting a new term" above for a detailed description (jump to the section that speaks about markdown).
+
+## Help translate the glossary {#help-translate-the-glossary}
+
+To help translate the glossary into your native language, please join the [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) channel on the CNCF Slack and let us know.
+You can either join an existing team or create a new one 
+(to see what it takes, check out or [Localization Guide](https://github.com/cncf/glossary/blob/main/LOCALIZATION.md)). 
+Please also join our monthly Glossary Working Group meetings. You can find meeting details in the [CNCF calendar](https://www.cncf.io/calendar/). 
+We look forward to meeting you there!

--- a/content/fr/contribute/_index.md
+++ b/content/fr/contribute/_index.md
@@ -1,169 +1,175 @@
 ---
-title: How To Contribute
+title: Comment contribuer
 toc_hide: true
 menu:
   main:
     weight: 10
 ---
 
-The Cloud Native Glossary content is stored in [this GitHub repo](https://github.com/cncf/glossary) 
-where you'll find a list of [issues](https://github.com/cncf/glossary/issues), [PRs](https://github.com/cncf/glossary/pulls), and 
-[discussions](https://github.com/cncf/glossary/discussions) about the glossary. 
+Le contenu du glossaire Cloud Native est stocké dans [ce repos Github](https://github.com/cncf/glossary) où vous trouverez une liste d'[issues](https://github.com/cncf/glossary/issues),[PRs](https://github.com/cncf/glossary/pulls), et [discussions](https://github.com/cncf/glossary/discussions) à propos du glossaire. 
 
-There are four ways you can contribute:
+Vous pouvez contribuer de 4 façons :
 
-1) [Work on an existing issue](#work-on-an-existing-issue)
-2) [Propose new terms](#propose-new-terms)
-3) [Update existing ones](#update-an-existing-term)
-4) [Help translate the glossary](#help-translate-the-glossary)
+1) [Travailler sur une issue existante](#work-on-an-existing-issue)
+2) [Proposer un nouveau termes](#propose-new-terms)
+3) [En mettre à jour un existant](#update-an-existing-term)
+4) [Aider à traduire le glossaire](#help-translate-the-glossary)
 
-## Join the Glossary community! {#join-the-glossary-community}
+## Rejoindre la communauté du glossaire ! {#join-the-glossary-community}
+Envisager de rejoindre la réunion mensuelle du groupe de travail du glossaire si vous souhaitez contribuer de manière régulière.
+Les détails de la réunion peuvent être trouvés dans le [calendrier de la CNCF](https://www.cncf.io/calendar/).
+Vous pouvez aussi entrer en contact avec les mainteneurs et les contributeurs de notre [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) sur le Slack de la CNCF - Nous aimerions beaucoup vous rencontrer!
 
-Consider joining our monthly Glossary Working Group meetings if you want to contribute regularly. 
-You can find meeting details in the [CNCF calendar](https://www.cncf.io/calendar/). 
-You can also connect with the maintainers and fellow contributors in our [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel on the CNCF Slack 
-— we'd love to meet you! 
 
-## Work on an existing issue {#work-on-an-existing-issue}
+## Travailler sur une issue existante {#work-on-an-existing-issue}
 
-Go to the [Glossary GitHub repo issues](https://github.com/cncf/glossary/issues). 
-There you'll see a list of all issues. You can filter by label (e.g. English language, help needed, good first issue). 
-Note that you'll need a GitHub account to do any of this.
+Aller sur [Glossary GitHub repo issues](https://github.com/cncf/glossary/issues). 
+Ici, vous trouverez une liste de toutes les issues. Vous pouvez les filtrer par label (e.g. English language, help needed, good first issue).
 
-![Issue and labels](/images/how-to/issue-and-labels.png)
+Un compte Github sera nécessaire.
 
-Make sure the term you are interested in is not already assigned to someone. 
-Here you can see that the first three terms are available while the next term has already been assigned.
+![Issue et labels](/images/how-to/issue-and-labels.png)
 
-![assigning a term](/images/how-to/howto-04.png)
+Faites en sorte qu'un terme qui vous intéresse ne soit pas déjà attribué à quelqu'un d'autre.
+Ici, vous pourrez voir que les 3 premiers termes disponibles alors que le suivant est déjà attribué.
 
-Once you found a term you want to work on, say so in the issue. Click on it and add a comment.
 
-![Claiming an issue](/images/how-to/claiming-an-issue.png)
+![Assigné un termes](/images/how-to/howto-04.png)
 
-Additionally, please also join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel on the CNCF Slack and 
-let the maintainers know that you've raised an issue for a new term 
-(ideally, tag _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, and/or _@iamnoah_ to be sure they don't miss it). 
-Note that you can only claim one term at a time. 
-If you want to work on multiple terms, please finish one before claiming the next one.
+Une fois que vous avez trouvé le terme sur lequel vous voulez travailler, dites-le dans l'issue. Cliquez dessus et rajouter un commentaire.
 
-Once they assign it to you, you can start working on it. 
-For the next steps, please refer to the [Submitting a new term (creating a PR)](#submitting-a-new-term) section.
 
-## Propose new terms {#propose-new-terms}
+![S'assigner une issue](/images/how-to/claiming-an-issue.png)
 
-You can propose a new term for others to work on or create a new definition yourself. 
-Either way, you'll start by creating an issue. 
-Please note that terms must meet the [CNCF's cloud native definition](https://github.com/cncf/toc/blob/main/DEFINITION.md). 
-The only exceptions are foundational terms needed to understand cloud native concepts.
+Additionellement, merci de rejoindre le channel Slack [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) et de faire savoir aux mainteneurs que vous avez créé une issue pour un terme (idéalement, en mentionnant, _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, et/ou _@iamnoah_ pour être sûr qu'il ne passe pas à côté).
 
-Below is a step-by-step guide for those not yet familiar with GitHub. 
-**If you are a GitHub Pro**, please _do_ have a quick look to make sure you use our issue templates, 
-appropriate naming conventions, claim a PR on Slack (otherwise we may miss it), and where to find the file template. 
-And please make sure to read the [Style Guide](/style-guide/) before getting started — thank you! 
+Vous pouvez uniquement proposer un terme à la fois.
 
-### Creating an issue {#creating-an-issue}
+Si vous voulez travailler sur plusieurs termes, merci d'en finir un avant d'en proposer un nouveau.
 
-Go to the [Glossary GitHub repo](https://github.com/cncf/glossary/issues) issues and click on "New issue".
+Une fois qu'il vous a été assigné, vous pouvez commencer à travailler dessus.
+Pour les étapes suivantes, merci de prendre connaissance de la section [Proposer un nouveau terme (créer une PR)](#submitting-a-new-term).
+
+## Proposer un nouveau terme {#propose-new-terms}
+
+Vous pouvez proposer un nouveau terme à la communauté ou créer vous-même la définition de ce terme.
+Dans les deux cas, vous commencerez par créer une issue.
+Il est à noter que les termes doivent être en accord avec le [CNCF's cloud native definition](https://github.com/cncf/toc/blob/main/DEFINITION.md).
+Les seules exceptions sont les termes fondamentaux nécessaires pour comprendre les concepts cloud natif.
+
+Ci-après, un guide étape par étape pour ceux et celles qui ne sont pas familier avec Github
+**Si vous avez un compte GitHub Pro**, merci de vérifier que vous utilisez nos modèles d'issue,
+une convention de nommage appropriée, réclamé une PR sur Slack (autrement on pourrait l'avoir raté), et où trouver les modèles de fichier.
+Et merci de lire le [Style Guide](/style-guide/) avant de commencer - Merci!
+
+### Créer une issue {#creating-an-issue}
+
+Aller sur les issues du repos [Glossary](https://github.com/cncf/glossary/issues) et cliquer sur "New issue".
 
 ![issues](/images/how-to/howto-01.png)
 
-You'll see a variety of templates. To propose a new term in English, select "Request to add a new term (English)".
+Vous verrez plusieurs modèles. Pour proposer un nouveau terme en Français sélectionner "Request to add a new term (Optional:Non-English)".
+
 
 ![templates](/images/how-to/english-issue-template.jpg)
 
-Add the word you're suggesting, answer the two questions below, check the checkboxes, and hit "Submit new issue".
-If you're just proposing a new term, you're done! To work on it, follow the next steps.
+Ajouter le mot que vous suggérez, répondez aux deux questions d'en dessous, cocher la case et cliquer sur "Submit new issue".
+Si vous souhaitez juste proposer un nouveau terme, vous pouvez vous arrêter là! Pour travailler dessus suivez les étapes d'après.
 
-### Triaging your issue {#triaging-your-issue}
 
-Next, the maintainers will triage the issue. 
-That means they will assess if the term should be part of the Glossary 
-(note, not every term will be admitted. Terms should be established and widely-used cloud native terms).
+### Catégoriser votre issue {#triaging-your-issue}
 
-Please let the maintainers know that you've submitted a term on Slack as they may otherwise miss it. 
-Ideally, tag _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, and/or _@iamnoah_. 
-If the term is approved and you want to work on it, they'll assign it to you.
+Ensuite, les mainteneurs vont trier le ticket
+Cela veut dire qu'ils vont évaluer si votre terme peut être présent dans le glossaire (Il est à noter, que tous les termes ne sont pas admis. Les termes doivent faire partie des termes couramment utilisés dans l'eco-système Cloud Native).
 
-Note that you can only claim one term at a time. 
-If you want to work on multiple terms, please finish one before claiming the next.
+Merci de faire savoir aux mainteneurs que vous avez soumis un terme sur Slack, sinon il pourrait passer à côté.
+Idéalement, mentionnez _@Catherine Paganini_, _@jmo_, _@Seokho Son_, _@Jihoon Seo_, and/or _@iamnoah_. 
 
-### Submitting a new term (creating a PR) {#submitting-a-new-term}
+Si le terme est approuvé et que vous voulez travailler dessus, ils vous assigneront l'issue.
 
-Before getting started, please read the [Style Guide](/style-guide/) — it will help minimize backs and forth. 
-As stated in the style guide, we highly recommend starting with a Google or Word doc. 
+Notez que vous pouvez vous assigner qu'à un seul terme à la fois.
+Si vous souhaitez travailler sur plusieurs termes, merci d'en finir un avant de vous en attribuer un autre
 
-Once the term is ready to submit, go to content (under code)…
+### Proposer un nouveau terme (créer une PR) {#submitting-a-new-term}
+
+Avant de commencer, merci de lire le [Style Guide](/style-guide/) — il aidera à minimiser les aller/retour.
+Comme mentionné dans le style guide, il est fortement recommandé de commencer par un document texte (Gdoc, Word ou autre)
+
+Une fois que le terme est prêt à être proposé, rédigez le contenu (sous forme de code)...
+
 
 ![content](/images/how-to/howto-05.png)
 
-…then "en" (or the language you are submitting for)…
+...Alors "fr" (ou la langue pour laquelle vous souhaitez contribuer)...
 
 ![language folder](/images/how-to/howto-06.png)
 
-…and select `_TEMPLATE.md`
+... Et sélectionner `_TEMPLATE.md` 
 
 ![template](/images/how-to/howto-07.png)
 
-Copy the content…
+...Copier le contenu...
 
 ![copy content](/images/how-to/howto-08.png)
 
-…and go back to the "en" folder. Hit "Add file" and select "Create new file".
+...Et retourner sur le dossier "fr". Et cliquer sur "Add file" et sélectionner "Create new file".
+
 
 ![create new file](/images/how-to/howto-09.png)
 
-Add the term name in the URL (no capitalization, no spaces, no parentheses, and use hyphens to separate words)
-and .md at the end (note: if your preview doesn't work, you probably forgot to add .md at the end).
-Now paste the template content below. Copy and paste your definition into the file.
-To make reviews easier, please **use [semantic line breaks](https://sembr.org/)** (e.g. one line per sentence).
-Note that GitHub uses markdown to format the text (e.g., hyperlink, bold, italic).
-Please refer to this [markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/).
-To verify you've used markdown as intended, go to "Preview".
+Ajouter le terme dans l'url (pas de majuscules, pas d'espaces, pas de parenthèses et utiliser un tirer pour séparer les mots) rajouter .md à la fin du nom de votre fichier (note: Si la prévisualisation ne fonctionne pas, vous avez probablement oublié d'ajouter .md à la fin).
+Maintenant copier le contenu. Copier et coller votre définition dans le fichier.
+Pour faciliter les relectures, merci **d'utiliser [semantic line breaks](https://sembr.org/)** (e.g. une ligne par phrase).
+
+Github utilise le format markdown pour mettre en forme le text (e.g., lien hypertexte, gras, italic).
+Merci de lire ceci [markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/).
+Pour vérifier que vous avez correctement utilisé markdown, aller sur "Preview".
+
 
 ![finalize term](/images/how-to/howto-10.png)
 
-Scroll down and name the new commit file when you are ready to submit. 
-You are now about to commit the term to your own branch. 
-Submitting a PR requires one more step. Hit "Commit new file" and…
+Descendre en bas de la page et donner un nom à votre commit quand vous êtes prêt à l'ajouter.
+Vous êtes, maintenant, prêt à commit votre terme sur votre propre branche.
+Proposer une PR nécessite une dernière étape. Cliquer sur "Commit new file" et...
 
 ![commit new file](/images/how-to/howto-11.png)
 
-…now you're creating an PR:
+...Maintenant vous créez une PR :
 
 ![create a pr](/images/how-to/howto-12.png)
 
-You should now see your PR under "Pull requests".
+Vous devriez voir votre PR sous "Pull requests".
 
 ![prs](/images/how-to/howto-13.png)
 
-## Update an existing term {#update-an-existing-term}
+## Mettre à jour un terme existant {#update-an-existing-term}
 
-To update an existing term, you can either suggest a change via an issue or go ahead and update the term directly by submitting a pull request (PR).
+Pour mettre à jour un terme existant, vous pouvez soit suggérer un changement via un ticket (issue) ou directement proposer la mise à jour d'un terme en soumettant une pull request (PR).
 
-### Request a change via an issue {#request-a-change-via-an-issue}
+### Proposer un changement via un ticket {#request-a-change-via-an-issue}
 
-If you want to flag a problem with a term but don't know how or want to fix it yourself, click on "Report issue".
+Si vous voulez mettre en évidence un problème mais que vous ne savez pas ou ne voulez pas le corriger vous même, cliquez sur "Report issue'.
 
 ![report issue](/images/how-to/howto-14.png)
 
-This will directly open an issue. Please elaborate on which change is needed and why. Hit submit, and that's it. 
+Cela va directement ouvrir un ticket. Merci d'être précis sur quels changements sont nécessaires et pourquoi. Cliquer sur "submit" et c'est fini.
+
 
 ![submit issue](/images/how-to/howto-15.png)
 
-### Update a term directly {#update-a-term-directly}
+### Mettre à jour un terme directement {#update-a-term-directly}
 
-To change a term directly, go to "Edit this page".
+Pour directement changer un terme, aller sur "Edit this page".
 
 ![edit this page](/images/how-to/howto-16.png)
 
-This will open the term's GitHub page. Make your changes and submit a PR. 
-Please refer to "Submitting a new term" above for a detailed description (jump to the section that speaks about markdown).
+Cela va ouvrir la page GitHub du terme. Faites vos changements et proposer une PR. Merci de prendre connaissance de "Proposer un nouveau terme" avant pour une description détaillé (sauter la section qui parle de markdown)
 
-## Help translate the glossary {#help-translate-the-glossary}
 
-To help translate the glossary into your native language, please join the [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) channel on the CNCF Slack and let us know.
-You can either join an existing team or create a new one 
-(to see what it takes, check out or [Localization Guide](https://github.com/cncf/glossary/blob/main/LOCALIZATION.md)). 
-Please also join our monthly Glossary Working Group meetings. You can find meeting details in the [CNCF calendar](https://www.cncf.io/calendar/). 
-We look forward to meeting you there!
+## Aider à traduire le glossaire {#help-translate-the-glossary}
+
+Pour aider à traduire le glossaire dans votre langue principale, merci de rejoindre le Slack et le channel [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) et faites le nous savoir.
+
+Vous pouvez soit rejoindre une équipe existante ou en créer une nouvelle (pour voir en quoi ça consiste, regarder [Localization Guide](https://github.com/cncf/glossary/blob/main/LOCALIZATION.md)).
+
+Merci aussi de rejoindre notre réunion mensuelle. Vous pouvez trouver plus de détails sur le [CNCF calendar](https://www.cncf.io/calendar/). 

--- a/content/fr/style-guide/_index.md
+++ b/content/fr/style-guide/_index.md
@@ -1,35 +1,38 @@
 ---
-title: Style Guide
+title: Guide de rédaction
 toc_hide: true
 menu:
   main:
     weight: 10
 ---
 
+Ce guide de rédaction aide à comprendre la cible du Glossaire, la structure des définitions, le niveau requis de détails, ainsi que la manière
+de maintenir un style constant.
 This style guide will help you understand the Glossary audience, definition structure, required level of detail, and how to maintain a consistent style.
 
-The Cloud Native Glossary follows the [default style guide](https://github.com/cncf/foundation/blob/master/style-guide.md) of the CNCF repository. 
-Additionally, it follows the following rules:
+Le Glossaire Cloud Natif suit le guide de [rédaction de référence](https://github.com/cncf/foundation/blob/master/style-guide.md) du dépôt de la CNCF.
 
-1. Use simple, accessible language, avoiding technical jargon and buzzwords
-2. [Avoid colloquial language](https://en.wikipedia.org/wiki/Colloquialism)
-3. [Use literal and concrete language](https://guidetogrammar.org/grammar/composition/abstract.htm)
-4. [Omit contractions](https://en.wikipedia.org/wiki/Contraction_(grammar))
-5. [Use passive voice sparingly](https://www.ef.com/ca/english-resources/english-grammar/passive-voice/)
-6. [Aim to phrase statements in a positive form](https://examples.yourdictionary.com/positive-sentence-examples.html) 
-7. [No exclamation marks outside of quotations](https://www.grammarly.com/blog/exclamation-mark/)
-8. Do not exaggerate
-9. Avoid repetition
-10. Be concise
+De plus, les règles suivantes sont appliquées:
 
-## Audience
+1. Utiliser un langage simple, accessible, et éviter les jargon technique ainsi que les buzzwords.
+2. [Éviter le langage du registre familier](https://fr.wikipedia.org/wiki/Registre_familier)
+3. [Employer un langage litéral et concret](https://guidetogrammar.org/grammar/composition/abstract.htm)
+4. [S'abstenir des contractions](https://fr.wikipedia.org/wiki/Contraction_(grammaire))
+5. [Privilégier la forme passive](http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=4267)
+6. [Favoriser des tournures de phrase positives](http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=4267)
+7. [Aucun point d'exclamation en dehors des citations](http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=3333)
+8. Ne pas exagérer
+9. Éviter les répétitions
+10. Être concis
 
-The Glossary is written for a technical AND non-technical audience. 
-Please ensure definitions are explained in simple terms and don’t assume technical knowledge. More do that below under Definition. 
+## Cibles
 
-## Definition Template
+Le Glossaire est rédigé comme référence technique ET non-technique.
+Merci de s'assurer que les définitions sont expliquées en termes simples et ne pas assumer que les lecteurs ont un bagage technique. Plus d'informations dans la section Définition.
 
-Each glossary term is stored in a markdown file and follows this template:
+## Modèle de définition
+
+Chaque terme du glossaire est stocké dans un fichier au format markdown, et suit le modèle suivant:
 
 ```md
 ---
@@ -38,49 +41,51 @@ status:
 category: 
 ---
 
-## What it is
+## Qu'est-ce donc
 
-A quick summary of the technology or concept.
+Un bref descriptif de la technologie ou du concept.
 
-## Problem it addresses 
+## Problème addressé
 
-A few lines about the problem it's addressing.
+Quelques lignes à propos du problèmes addressés par l'entité.
 
-## How it helps
+## Quel en est l'utilité
 
-A few lines on how the thing solves the problem.
+Quelques lignes sur comment cette entité résoud le problème.
 ```
 
-### Title
+### Titre
 
-The **title** label will always be at the top of a definition layout, and its value should be in title case. 
+L'étiquette **title** est toujours placé en haut de la disposition, et sa valeur doit toujours être en majuscule.
 
 ```md
 ---
-title: Definition Template
+title: Modèle de définition
 ```
 
 ### Status
 
-The **status** label will come after the title label. The status label indicates whether definitions are thoroughly vetted or require more effort.
+L'étiquette **status** vient après l'étiquette label. Cette étiquette indique si les définitions ont été soigneusement contrôlées, ou si l'explication
+nécessite plus de travail.
 
-Valid values are: 
+Les valeurs acceptées sont:
 
 - Completed
-- Feedback Appreciated 
+- Feedback Appreciated
 - Not Started
 
-You can always open an issue against a completed definition. While a definition is in flux, its status will be changed to *Feedback Appreciated*.
+Il est toujours possible d'ouvrir un ticket concernant une définition complétée (status "Completed"). Lorsque une définition est sujette au changement, son
+status sera changé à *Feedback Appreciated*.
 
 ```md
 ---
-title: Definition Template
+title: Modèle de définition
 status: Feedback Appreciated
 ```
 
 ### Category
 
-The **category** label will come after the status label. Its value should be one of the following values:
+L'étiquette **category** vient après celle du status. Sa valeur doit être l'une des possibilités suivantes:
 
 - Technology
 - Property
@@ -88,26 +93,26 @@ The **category** label will come after the status label. Its value should be one
 
 ```md
 ---
-title: Definition Template
+title: Modèle de définition
 status: Feedback Appreciated
 category: Concept
 ---
 ```
 
-### Definition
+### Définition
 
-#### Three subheadings
+#### Trois sous-sections
 
-The definitions for **technology** and **concept** categories contain three subheadings: 
+Les définitions pour les catégories **technology** et **concept** contiennent trois sous-sections:
 
-- **What it is**: provide a short and clear overview of what we are talking about.
-- **Problem it addresses**: focus on the problem, not the solution (that comes in the next section). 
-  In fact, avoid mentioning the term that is defined. The problem focuses on *what* led us to need that thing. 
-- **How it helps**: now, come back to the term. How does it address the problem described above?
+- **Qu'est-ce donc** : fournis une explication claire et concise de ce dont nous parlons.
+- **Problème addressé** : se concentre sur le problème, pas la solution (cela vient dans la section suivante).
+  Pour faire simple, éviter de mentionner le terme qui est défini. Le problème nous aide à nous concentrer sur *ce qui* nous à mené à avoir besoin de cette entité.
+- **Quel en est l'utilité**: maintenant, revenir sur le terme en lui-même. Comment est-ce qu'il addresse le problème décrit précédemment ?
 
-Note that **properties** don't require separate sections. A definition will suffice. 
+Noter que les propriétés ne nécessitent pas de section séparée. Un définition suffira.
 
-To facilitate review, please use **semantic line breaks** (one sentence per line).
+Pour faciliter la revue, merci d'utiliser les **sauts à la ligne sémantiques** (une phrase par ligne).
 
 #### Quality is paramount
 

--- a/content/fr/style-guide/_index.md
+++ b/content/fr/style-guide/_index.md
@@ -8,7 +8,6 @@ menu:
 
 Ce guide de rédaction aide à comprendre la cible du Glossaire, la structure des définitions, le niveau requis de détails, ainsi que la manière
 de maintenir un style constant.
-This style guide will help you understand the Glossary audience, definition structure, required level of detail, and how to maintain a consistent style.
 
 Le Glossaire Cloud Natif suit le guide de [rédaction de référence](https://github.com/cncf/foundation/blob/master/style-guide.md) du dépôt de la CNCF.
 
@@ -107,7 +106,7 @@ Les définitions pour les catégories **technology** et **concept** contiennent 
 
 - **Ce que c'est** : fournis une explication claire et concise de ce dont nous parlons.
 - **Problème qu'il adresse** : se concentre sur le problème, pas la solution (cela vient dans la section suivante).
-  Pour faire simple, éviter de mentionner le terme qui est défini. Le problème nous aide à nous concentrer sur *ce qui* nous à mené à avoir besoin de cette entité.
+  Pour faire simple, éviter de mentionner le terme qui est défini. Le problème nous aide à nous concentrer sur *ce qui* nous a mené à avoir besoin de ce terme.
 - **Quel en est l'utilité**: maintenant, revenir sur le terme en lui-même. Comment est-ce qu'il adresse le problème décrit précédemment ?
 
 Noter que les propriétés ne nécessitent pas de section séparée. Un définition suffira.
@@ -120,7 +119,7 @@ Si vos modifications sont acceptées, vos changements seront les définitions of
 par une autre personne).
 La création d'un terme qui respecte les standards élevés de la CNCF ne doit pas se faire précipitamment - la qualité requiert du temps et de l'effort.
 
-**Faites vos recherches**: Même si vous avez confiance en votre connaissance du terme, vérifiez que avez la bonne définition.
+**Faites vos recherches**: Même si vous avez confiance en votre connaissance du terme, vérifiez que vous avez la bonne définition.
 L'utilisation des termes en entreprise ne reflètent pas toujours la globalité.
 Lorsque vous effectuez vos recherches, essentiellement lorsque vous n'êtes pas 100% familier avec ce dernier, utilisez plusieurs sources.
 De nombreuses définitions ne sont pas unilatérales, spécifiquement lorsqu'elles sont issues d'une solution propriétaire.
@@ -152,7 +151,7 @@ Lorsque cela est possible, tentez de faire cette connexion.
 #### Débuter avec un document Google ou Word
 
 Nous recommandons de débuter les modifications dans un document Google ou Word, de laisser reposer votre définitions pendant quelques jours, et d'y revenir par la suite.
-Aussi, assurez-vous d'effectuer une vérification orthographique avec de soumettre votre PR.
+Aussi, assurez-vous d'effectuer une vérification orthographique avant de soumettre votre PR.
 
 Afin d'éviter qu'un autre contributeur soumette une PR concernant le terme sur lequel vous travaillez,
 assurez-vous de vous approprier un ticket (ou d'en créer un) et qu'il vous soit assigné.
@@ -168,7 +167,7 @@ Occasionnellement, nous serons capables de revoir les termes rapidement; en d'au
 Si vous avez des questions, n'hésitez pas à nous contacter sur le canal Slack #glossary (pour savoir où et comment le trouver, référez-vous à la section de [Comment contribuer](/contribute/)).
 
 Notre but est de faire du Glossaire la meilleure des ressources possible.
-Une fois que vous aurez soumis votre PR, il est possible de nous demandions une ou plusieurs révisions.
+Une fois que vous aurez soumis votre PR, il est possible que nous demandions une ou plusieurs révisions.
 Ne soyez pas frustré - c'est le cas pour un grand nombre de PRs.
 Ces allers-retours et notre collaboration assureront que votre contribution devienne une définition réellement
 utile, lue et référée par de nombreux lecteurs aux quatres coins du monde.

--- a/content/fr/style-guide/_index.md
+++ b/content/fr/style-guide/_index.md
@@ -1,0 +1,168 @@
+---
+title: Style Guide
+toc_hide: true
+menu:
+  main:
+    weight: 10
+---
+
+This style guide will help you understand the Glossary audience, definition structure, required level of detail, and how to maintain a consistent style.
+
+The Cloud Native Glossary follows the [default style guide](https://github.com/cncf/foundation/blob/master/style-guide.md) of the CNCF repository. 
+Additionally, it follows the following rules:
+
+1. Use simple, accessible language, avoiding technical jargon and buzzwords
+2. [Avoid colloquial language](https://en.wikipedia.org/wiki/Colloquialism)
+3. [Use literal and concrete language](https://guidetogrammar.org/grammar/composition/abstract.htm)
+4. [Omit contractions](https://en.wikipedia.org/wiki/Contraction_(grammar))
+5. [Use passive voice sparingly](https://www.ef.com/ca/english-resources/english-grammar/passive-voice/)
+6. [Aim to phrase statements in a positive form](https://examples.yourdictionary.com/positive-sentence-examples.html) 
+7. [No exclamation marks outside of quotations](https://www.grammarly.com/blog/exclamation-mark/)
+8. Do not exaggerate
+9. Avoid repetition
+10. Be concise
+
+## Audience
+
+The Glossary is written for a technical AND non-technical audience. 
+Please ensure definitions are explained in simple terms and don’t assume technical knowledge. More do that below under Definition. 
+
+## Definition Template
+
+Each glossary term is stored in a markdown file and follows this template:
+
+```md
+---
+title: 
+status: 
+category: 
+---
+
+## What it is
+
+A quick summary of the technology or concept.
+
+## Problem it addresses 
+
+A few lines about the problem it's addressing.
+
+## How it helps
+
+A few lines on how the thing solves the problem.
+```
+
+### Title
+
+The **title** label will always be at the top of a definition layout, and its value should be in title case. 
+
+```md
+---
+title: Definition Template
+```
+
+### Status
+
+The **status** label will come after the title label. The status label indicates whether definitions are thoroughly vetted or require more effort.
+
+Valid values are: 
+
+- Completed
+- Feedback Appreciated 
+- Not Started
+
+You can always open an issue against a completed definition. While a definition is in flux, its status will be changed to *Feedback Appreciated*.
+
+```md
+---
+title: Definition Template
+status: Feedback Appreciated
+```
+
+### Category
+
+The **category** label will come after the status label. Its value should be one of the following values:
+
+- Technology
+- Property
+- Concept
+
+```md
+---
+title: Definition Template
+status: Feedback Appreciated
+category: Concept
+---
+```
+
+### Definition
+
+#### Three subheadings
+
+The definitions for **technology** and **concept** categories contain three subheadings: 
+
+- **What it is**: provide a short and clear overview of what we are talking about.
+- **Problem it addresses**: focus on the problem, not the solution (that comes in the next section). 
+  In fact, avoid mentioning the term that is defined. The problem focuses on *what* led us to need that thing. 
+- **How it helps**: now, come back to the term. How does it address the problem described above?
+
+Note that **properties** don't require separate sections. A definition will suffice. 
+
+To facilitate review, please use **semantic line breaks** (one sentence per line).
+
+#### Quality is paramount
+
+If merged, your submission will be the official CNCF definition for that term (until someone else improves it). 
+Creating a term that meets the CNCF's high standards can't be rushed — quality takes time and effort.
+
+**Do your research**: Even if you are confident you know the term, verify you got it right. 
+We often use terms in organizations a certain way that may not reflect the full picture. 
+When you do your research, especially when you're not 100% familiar with the term, use multiple resources. 
+Many definitions are one-sided, especially if provided by a vendor. 
+The Glossary must contain vendor-neutral, globally accepted definitions.
+
+**Don't plagiarize**. The same rules apply to Glossary as to any other serious publication. 
+Don't copy and paste other people's work unless you are quoting and contributing it to them. 
+If you like a particular section of a definition, paraphrase it in your own words.
+
+**Reference authoritative resources**. When possible, link to authoritative resources such as project docs. 
+Note that we cannot link to content developed by vendors. 
+
+#### Keeping it simple
+
+The Glossary aims at **explaining complex concepts in simple words** — that is a surprisingly difficult task that will likely take multiple revisions. 
+Always keep the audience in mind when drafting your definition. 
+Avoid using industry terms and buzzwords — you'll probably catch yourself going back to them and may need to autocorrect. 
+
+When appropriate, use **real-world examples** that help readers (especially non-technical ones) better understand *when* and *why* the concept you’re explaining is relevant. 
+
+When used in your definition, always **link to existing glossary terms** (only the first mention should be hyperlinked).
+
+**Example**: take a look at the “What it is” section of the [service mesh definition](/service-mesh/). 
+It links back to the microservices, service, reliability, and observability definitions. 
+Additionally, it uses a real-world example comparing network challenges in a microservices environment (something non-technical people can't relate to) 
+to wifi problems (something anyone using a laptop can understand). 
+Where possible, try to make that connection. 
+
+#### Start with a Google or Word doc
+
+We recommend starting with a Google or Word doc, letting it sit for a few days, and revisiting again. 
+This will allow you to catch phrases or expressions that could be worded in a simpler and more accessible way. 
+Also, make sure to run a spellcheck before submitting a PR.
+
+To ensure no one else submits a PR while working on a term, make sure to claim an issue (or create one) and that it is assigned to you. 
+More to that in the [How To Contribute](/contribute/) doc.
+
+Before getting started, please read some of the published Glossary terms 
+to get a feeling for the level of detail and difficulty and when examples are appropriate.
+
+## The review process: what to expect
+
+Please note that we are currently only three maintainers doing this in their spare time. 
+Occasionally, we'll be able to review terms quickly; on other occasions, it may take some time — we appreciate your patience. 
+If you have any questions, please get in touch with us in the #glossary Slack channel 
+(for where and how to find it, please refer to our [How To Contribute](/contribute/) doc).
+
+Our goal is for the Glossary to be the best possible resource. 
+Once you submit a PR, we may ask for one or more revisions. 
+Don't be frustrated — that is the case for many PRs. 
+Those backs and forth and our collaboration will ensure that your contribution becomes a truly useful definition read and referred to by readers all around the globe.

--- a/content/fr/style-guide/_index.md
+++ b/content/fr/style-guide/_index.md
@@ -16,7 +16,7 @@ De plus, les règles suivantes sont appliquées:
 
 1. Utiliser un langage simple, accessible, et éviter les jargon technique ainsi que les buzzwords.
 2. [Éviter le langage du registre familier](https://fr.wikipedia.org/wiki/Registre_familier)
-3. [Employer un langage litéral et concret](https://guidetogrammar.org/grammar/composition/abstract.htm)
+3. [Employer un langage littéral et concret](https://guidetogrammar.org/grammar/composition/abstract.htm)
 4. [S'abstenir des contractions](https://fr.wikipedia.org/wiki/Contraction_(grammaire))
 5. [Privilégier la forme passive](http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=4267)
 6. [Favoriser des tournures de phrase positives](http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=4267)
@@ -41,17 +41,17 @@ status:
 category: 
 ---
 
-## Qu'est-ce donc
+## Ce que c'est
 
 Un bref descriptif de la technologie ou du concept.
 
-## Problème addressé
+## Problème qu'il adresse
 
-Quelques lignes à propos du problèmes addressés par l'entité.
+Quelques lignes à propos du problème qu'il adresse.
 
 ## Quel en est l'utilité
 
-Quelques lignes sur comment cette entité résoud le problème.
+Quelques lignes sur comment le problème est résolu.
 ```
 
 ### Titre
@@ -105,69 +105,70 @@ category: Concept
 
 Les définitions pour les catégories **technology** et **concept** contiennent trois sous-sections:
 
-- **Qu'est-ce donc** : fournis une explication claire et concise de ce dont nous parlons.
-- **Problème addressé** : se concentre sur le problème, pas la solution (cela vient dans la section suivante).
+- **Ce que c'est** : fournis une explication claire et concise de ce dont nous parlons.
+- **Problème qu'il adresse** : se concentre sur le problème, pas la solution (cela vient dans la section suivante).
   Pour faire simple, éviter de mentionner le terme qui est défini. Le problème nous aide à nous concentrer sur *ce qui* nous à mené à avoir besoin de cette entité.
-- **Quel en est l'utilité**: maintenant, revenir sur le terme en lui-même. Comment est-ce qu'il addresse le problème décrit précédemment ?
+- **Quel en est l'utilité**: maintenant, revenir sur le terme en lui-même. Comment est-ce qu'il adresse le problème décrit précédemment ?
 
 Noter que les propriétés ne nécessitent pas de section séparée. Un définition suffira.
 
 Pour faciliter la revue, merci d'utiliser les **sauts à la ligne sémantiques** (une phrase par ligne).
 
-#### Quality is paramount
+#### La qualité est primordiale
 
-If merged, your submission will be the official CNCF definition for that term (until someone else improves it). 
-Creating a term that meets the CNCF's high standards can't be rushed — quality takes time and effort.
+Si vos modifications sont acceptées, vos changements seront les définitions officielles de la CNCF pour ce terme (jusqu'à ce qu'ils soient mis à jour
+par une autre personne).
+La création d'un terme qui respecte les standards élevés de la CNCF ne doit pas se faire précipitamment - la qualité requiert du temps et de l'effort.
 
-**Do your research**: Even if you are confident you know the term, verify you got it right. 
-We often use terms in organizations a certain way that may not reflect the full picture. 
-When you do your research, especially when you're not 100% familiar with the term, use multiple resources. 
-Many definitions are one-sided, especially if provided by a vendor. 
-The Glossary must contain vendor-neutral, globally accepted definitions.
+**Faites vos recherches**: Même si vous avez confiance en votre connaissance du terme, vérifiez que avez la bonne définition.
+L'utilisation des termes en entreprise ne reflètent pas toujours la globalité.
+Lorsque vous effectuez vos recherches, essentiellement lorsque vous n'êtes pas 100% familier avec ce dernier, utilisez plusieurs sources.
+De nombreuses définitions ne sont pas unilatérales, spécifiquement lorsqu'elles sont issues d'une solution propriétaire.
+Le Glossaire se doit de contenir des définitions neutres de toute solution propriétaire, et globales.
 
-**Don't plagiarize**. The same rules apply to Glossary as to any other serious publication. 
-Don't copy and paste other people's work unless you are quoting and contributing it to them. 
-If you like a particular section of a definition, paraphrase it in your own words.
+**Ne pas plagier**. Comme toute publication sérieuse, le Glossaire se doit d'appliquer les mêmes règles.
+Ne pas copier et coller le travail d'autrui, à mois que ce ne soit une citation ou contribution.
+Si une section particulière d'une définition vous parait appropriée, paraphrasez-la avec vos propres mots.
 
-**Reference authoritative resources**. When possible, link to authoritative resources such as project docs. 
-Note that we cannot link to content developed by vendors. 
+**Référencez les ressources faisant autorité**. Lorsque cela est possible, référencez les ressources faisant autorité sur le terme, telles que les documentations de projet.
+Notez qu'il n'est pas possible de référer des ressources développées par les vendeurs.
 
-#### Keeping it simple
+#### Rester simple
 
-The Glossary aims at **explaining complex concepts in simple words** — that is a surprisingly difficult task that will likely take multiple revisions. 
-Always keep the audience in mind when drafting your definition. 
-Avoid using industry terms and buzzwords — you'll probably catch yourself going back to them and may need to autocorrect. 
+Le Glossaire tend à **expliquer des concepts complexes avec des mots simples** - cette tâche est particulièrement difficile, et nécessitera de nombreuses révisions.
+Toujours garder à l'esprit le public cible lors de la rédaction d'une définition.
+Évitez l'utilisation de termes d'entreprise ou les buzzwords - vous vous retrouverez probablement obligé de vous corriger vous-même à plusieurs reprises sur ce point.
 
-When appropriate, use **real-world examples** that help readers (especially non-technical ones) better understand *when* and *why* the concept you’re explaining is relevant. 
+Lorsque la situation est appropriée, utiliser des **exemples de la vie réelle** qui peuvent aider les lecteurs (en particulier les moins techniques d'entre eux) à avoir une meilleure
+vision du *quand* et *pourquoi* du concept que vous expliquez.
 
-When used in your definition, always **link to existing glossary terms** (only the first mention should be hyperlinked).
+Lorsqu'utilisé dans vos définitions, toujours **rediriger vers des termes existant du Glossaire** (uniquement la première mention du terme doit-être redirigée).
 
-**Example**: take a look at the “What it is” section of the [service mesh definition](/service-mesh/). 
-It links back to the microservices, service, reliability, and observability definitions. 
-Additionally, it uses a real-world example comparing network challenges in a microservices environment (something non-technical people can't relate to) 
-to wifi problems (something anyone using a laptop can understand). 
-Where possible, try to make that connection. 
+**Exemple**: référez vous à la section "Ce que c'est" de la définition d'un [service mesh](/service-mesh/).
+Cette dernière fait référence aux définitions de micro-services, service, fiabilité, et observabilité.
+De plus, elle utilise un exemple de la vie réelle en comparant les enjeux des réseaux dans un environnement micro-services (un concept auquel un non-technique peut difficilement s'identifier) à une problématique de réseau wifi (ce que toute personne possédant un ordinateur peut comprendre).
+Lorsque cela est possible, tentez de faire cette connexion.
 
-#### Start with a Google or Word doc
+#### Débuter avec un document Google ou Word
 
-We recommend starting with a Google or Word doc, letting it sit for a few days, and revisiting again. 
-This will allow you to catch phrases or expressions that could be worded in a simpler and more accessible way. 
-Also, make sure to run a spellcheck before submitting a PR.
+Nous recommandons de débuter les modifications dans un document Google ou Word, de laisser reposer votre définitions pendant quelques jours, et d'y revenir par la suite.
+Aussi, assurez-vous d'effectuer une vérification orthographique avec de soumettre votre PR.
 
-To ensure no one else submits a PR while working on a term, make sure to claim an issue (or create one) and that it is assigned to you. 
-More to that in the [How To Contribute](/contribute/) doc.
+Afin d'éviter qu'un autre contributeur soumette une PR concernant le terme sur lequel vous travaillez,
+assurez-vous de vous approprier un ticket (ou d'en créer un) et qu'il vous soit assigné.
+Plus d'information sur la documentation de [Comment contribuer](/contribute/).
 
-Before getting started, please read some of the published Glossary terms 
-to get a feeling for the level of detail and difficulty and when examples are appropriate.
+Avant de démarrer, veillez à lire quelques termes du Glossaire afin de vous approprier le niveau de détails et de difficulté,
+ainsi que de l'utilisation judicieuse des exemples.
 
-## The review process: what to expect
+## Processus de revue: à quoi s'attendre
 
-Please note that we are currently only three maintainers doing this in their spare time. 
-Occasionally, we'll be able to review terms quickly; on other occasions, it may take some time — we appreciate your patience. 
-If you have any questions, please get in touch with us in the #glossary Slack channel 
-(for where and how to find it, please refer to our [How To Contribute](/contribute/) doc).
+Notez que nous ne sommes actuellement que 3 mainteneurs, effectuant ce travail sur notre temps personnel.
+Occasionnellement, nous serons capables de revoir les termes rapidement; en d'autres occasions, il est possible que cela prenne plus de temps - merci de votre patience.
+Si vous avez des questions, n'hésitez pas à nous contacter sur le canal Slack #glossary (pour savoir où et comment le trouver, référez-vous à la section de [Comment contribuer](/contribute/)).
 
-Our goal is for the Glossary to be the best possible resource. 
-Once you submit a PR, we may ask for one or more revisions. 
-Don't be frustrated — that is the case for many PRs. 
-Those backs and forth and our collaboration will ensure that your contribution becomes a truly useful definition read and referred to by readers all around the globe.
+Notre but est de faire du Glossaire la meilleure des ressources possible.
+Une fois que vous aurez soumis votre PR, il est possible de nous demandions une ou plusieurs révisions.
+Ne soyez pas frustré - c'est le cas pour un grand nombre de PRs.
+Ces allers-retours et notre collaboration assureront que votre contribution devienne une définition réellement
+utile, lue et référée par de nombreux lecteurs aux quatres coins du monde.

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -50,7 +50,7 @@ other = "Ouvrir un ticket de projet"
 [post_posts_in]
 other = "Postés dans"
 [post_reading_time]
-other = "temps de lecture"
+other = "minute(s) de lecture"
 
 # Print support
 [print_printable_section]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,0 +1,73 @@
+
+
+# UI strings. Buttons and similar.
+
+[ui_pager_prev]
+other = "Précédent"
+
+[ui_pager_next]
+other = "Suivant"
+
+[ui_read_more]
+other = "En savoir plus"
+
+[ui_search]
+other = "Rechercher sur ce site…"
+
+# Used in sentences such as "Posted in News"
+[ui_in]
+other = "dans"
+
+# Used in sentences such as "All Tags"
+[ui_all]
+other = "tous"
+[ui_see_all]
+other = "Voir tous"
+
+# Footer text
+[footer_all_rights_reserved]
+other = "Tous droits réservés"
+
+[footer_privacy_policy]
+other = "Politique de confidentialité"
+
+
+# Post (blog, articles etc.)
+[post_byline_by]
+other = "Par"
+[post_created]
+other = "Créé"
+[post_last_mod]
+other = "Dernière modification"
+[post_edit_this]
+other = "Modifier cette page"
+[post_create_child_page]
+other = "Créer une page enfant"
+[post_create_issue]
+other = "Ouvrir un ticket"
+[post_create_project_issue]
+other = "Ouvrir un ticket de projet"
+[post_posts_in]
+other = "Postés dans"
+[post_reading_time]
+other = "temps de lecture"
+
+# Print support
+[print_printable_section]
+other = "Ceci est la page d'impression multiple de cette section"
+[print_click_to_print]
+other = "Cliquer ici pour imprimer"
+[print_show_regular]
+other = "Retour à la vue standard de cette page"
+[print_entire_section]
+other = "Imprimer la section complète"
+
+# Feedback section
+[feedback_title]
+other = "Votre avis"
+[feedback_question]
+other = "Cette page était-elle utile ?"
+[feedback_answer_yes]
+other = "Oui"
+[feedback_answer_no]
+other = "Non"


### PR DESCRIPTION
This PR is to initiate French localization based on:
* Issue #915
* https://github.com/cncf/glossary/blob/main/LOCALIZATION.md Guide

Base and target branch of this PR is `dev-fr` which is development branch for French localization.

This PR includes:
* `[languages.fr]` section in `config.toml`
* `content/fr/` directory
* `i18n/fr.toml`
* Some translated documents:
    * Main page: `content/fr/_index.md`
    * contribute: `content/fr/contribute/_index.md`
    * style-guide: `content/fr/style-guide/_index.md`
* Others:
    * FR Template: `content/fr/_TEMPLATE.md`

Since French localization team owns content/fr/* only,
this PR will require approvals from upstream owners (maintainers).
