### PR TITLE
Update wordlist.txt to add multitenancy

### DIFF
--- a/wordlist.txt
+++ b/wordlist.txt
@@ -122,6 +122,7 @@ microservices
 misconfiguration
 mkdn
 mtls
+multitenancy
 navbar
 observability
 oci


### PR DESCRIPTION
Added "multitenancy".  Along with multi-tenancy, this is a common speling (e.g. https://en.wikipedia.org/wiki/Multitenancy)

Signed-off-by: Sergey Borovoy <48699431+sergeyborovoy@users.noreply.github.com>