### PR TITLE
Add Rodolfo Martinez to Spanish approver team

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -132,6 +132,9 @@ collaborators:
   - username: krol3
     permission: push
 
+  - username: ramrodo
+    permission: push
+
   # l10n zh approvers
   - username: hanyuancheung
     permission: push
@@ -323,6 +326,7 @@ branches:
          - raelga
          - electrocucaracha
          - krol3
+         - ramrodo
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,7 +34,7 @@
 /content/bn/ @mitul3737 @Mouly22 @ikramulkayes @Imtiaz1234
 
 # Approvers for Spanish contents
-/content/es/ @raelga @electrocucaracha @krol3
+/content/es/ @raelga @electrocucaracha @krol3 @ramrodo
 
 # Approvers for Chinese contents
 /content/zh-cn/ @hanyuancheung @Jacob953 @Rocksnake @Submarinee


### PR DESCRIPTION
Given his active [collaboration](https://github.com/cncf/glossary/pulls?q=author%3Aramrodo) in Spanish localization team, this PR recognizes the effort made by @ramrodo and promotes him to the approver role.

/cc @raelga @krol3 