### PR TITLE
[ko] Update i18n strings

### DIFF
--- a/content/ko/_TEMPLATE.md
+++ b/content/ko/_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 title: 용어 정의 템플릿
-status: Completed
+status: Feedback Appreciated
 category: 개념
 ---
 

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -12,15 +12,17 @@ other = "다음"
 other = "더 읽기"
 
 [ui_search]
-other = "이 사이트 검색하기…"
+other = "이 사이트 검색하기..."
 
 # Used in sentences such as "Posted in News"
 [ui_in]
-other = "내부"
+other = "in"
 
 # Used in sentences such as "All Tags"
 [ui_all]
 other = "모든"
+[ui_see_all]
+other = "모두 보기:"
 
 # Footer text
 [footer_all_rights_reserved]
@@ -32,9 +34,9 @@ other = "개인 정보 처리 방침"
 
 # Post (blog, articles etc.)
 [post_byline_by]
-other = "의해서"
+other = "작성자"
 [post_created]
-other = "생성된"
+other = "작성 일시"
 [post_last_mod]
 other = "최근 수정"
 [post_edit_this]
@@ -48,7 +50,7 @@ other = "프로젝트 이슈 생성하기"
 [post_posts_in]
 other = "포스트된 곳"
 [post_reading_time]
-other = "읽은 시간(분)"
+other = "읽는 데 걸리는 시간(분)"
 
 # Print support
 [print_printable_section]


### PR DESCRIPTION
[`content/ko/_TEMPLATE.md` 관련]

기존: 이 파일의 `status`가 `Completed`로 되어 있어서, left sidebar에 표출됩니다.
- https://deploy-preview-1122--cncfglossary.netlify.app/ko/_template/
- https://deploy-preview-1131--cncfglossary.netlify.app/ko/_template/

![image](https://user-images.githubusercontent.com/46767780/185023947-abba5b99-db84-4661-9d29-f2222d9194e6.png)


개선: `status`를 `Feedback Appreciated`로 바꿔서, left sidebar에 표출되지 않도록 했습니다.

향후 주의사항:
- 기여자가 PR 오픈 및 리뷰 의견 반영을 완료하여 PR 머지 직전일 때, 및
- `dev-ko` 의 커밋들을 `main`으로 넣는 PR에서,

해당 PR에 속한 파일의 `status`가 `Feedback Appreciated` 이면 `Completed` 로 바꿔야 합니다.

(그런데 실제로는 기여자가 `content/ko/_TEMPLATE.md` 를 복사하여 사용하기보다는
각 용어의 영문 파일을 복사하여 사용하는 경우가 대부분일 것이라서
이러한 상황은 거의 발생하지 않을 것 같습니다.)

---

[`i18n/ko.toml` 관련]
예를 들면 다음 페이지에서
- https://deploy-preview-1122--cncfglossary.netlify.app/ko/tags/애플리케이션/
- https://deploy-preview-1131--cncfglossary.netlify.app/ko/tags/인프라스트럭처/

![image](https://user-images.githubusercontent.com/46767780/185025056-3d7a523b-ec5b-488d-823b-d53eb8996830.png)

이렇게 표시되고 있어서
`i18n/ko.toml` 파일에
- `ui_see_all` 항목을 추가하고
- 다른 항목도 조금 업데이트 했습니다.

그런데, preview 확인하니 다음과 같이 표시됩니다.

![image](https://user-images.githubusercontent.com/46767780/185045610-2deaf57d-3a6e-4d39-83c3-ffddc1d87bb6.png)

---

![image](https://user-images.githubusercontent.com/46767780/185045652-0b1d91f6-f140-4abe-add1-5f50511d569a.png)

- "Tag" / "Tags" 항목이 `en.toml` 에 존재하지 않고
- `taxonomy.html` 파일의 해당 부분이 English에 적합하게 되어 있고 L10n에는 조금 적합하지 않게 되어 있어서

현재 이 repo의 i18n 상태로서는 해당 부분을 적절히 현지화하기가 어려워 보여,
별도의 이슈를 열겠습니다. 😊