### PR TITLE
Enable labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,14 +1,12 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - 'content/**'
-    branches:
-      - '**'
+- pull_request_target
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,7 @@ on:
       - 'content/**.md'
     branches:
       - 'dev-**'
+      - 'main'
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,11 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  pull_request_target:
+    types: [opened]
+    paths:
+      - 'content/**.md'
+    branches:
+      - 'dev-**'
 
 jobs:
   triage:


### PR DESCRIPTION
Signed-off-by: Seokho Son <shsongist@gmail.com>

### Describe your changes
- This PR is to update labeler workflow (automate labeling PRs)
  - https://github.com/actions/labeler#create-workflow
- The labeler workflow has been disabled to check a security issue within the labeler workflow. (a high level permission given to the `pull_request_target` option)
- According to some valuable discussions with @yunkon-kim , we concluded that the concern with the permission issue can be minimized. (please review and discuss if there is any other concern)

### Related issue number or link (ex: `resolves #issue-number`)
- NA

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco).
    
