### PR TITLE
[Do Not Merge] PoC: Add Git Hook for validate wordlist sorting

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Remember to execute "git config core.hooksPath .githooks" for having this git hook working
+
+REDBOLD="\033[0;31;1m"
+NORMAL="\033[0m"
+
+wordlist="content/es/.wordlist.txt"
+wordsUnsorted=$(diff --changed-group-format="%>%<" --unchanged-group-format="" <(cat $wordlist) <(sort $wordlist))
+commandToSort="sort -o content/es/.wordlist.txt content/es/.wordlist.txt"
+
+if [[ -n "$wordsUnsorted" ]]; then
+	echo -e >&2 "\n${REDBOLD}Words unsorted found at $wordlist ${NORMAL} \n\nPlease execute the following command to sort it: \n\n\t$commandToSort\n"
+	exit 1
+fi
+
+exit 0

--- a/content/es/.wordlist.txt
+++ b/content/es/.wordlist.txt
@@ -134,7 +134,6 @@ profesionistas
 properties
 propose
 PRs
-portable
 pull
 Rael
 Ramer


### PR DESCRIPTION
### Describe your changes

This PR:
- adds `.githooks` folder for track the Git Hook using git
- creates `pre-push` hook for validating if the words found at `content/es/.wordlist.txt` are well sorted
- fixes `.wordlist.txt` file since there is an error with the duplicated word **portable**

**Do Not Merge. This is just a PoC.**

TO DO:
- [ ] Support other wordlist from other languages

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [X] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [X] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco).
    
