### PR TITLE
add check if the term has already been declined in the past

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-term.yml
+++ b/.github/ISSUE_TEMPLATE/new-term.yml
@@ -32,6 +32,8 @@ body:
           required: true
         - label: There is no existing issue yet. [(shift+click to check existing issues)](https://github.com/cncf/glossary/issues?q=label%3A%22new+term%22)
           required: true
+        - label: The term has not already been declined in the past. [(shift+click to check)](https://github.com/cncf/glossary/issues?q=is%3Aissue+is%3Aclosed+label%3A%22triage%2Fnot+accepted%22)
+          required: false
         - label: The term does not already exist in the [glossary](https://glossary.cncf.io).
           required: true
         - label: I understand that maintainers will assess if the term should be part of the Glossary. (Please be patient)


### PR DESCRIPTION
### Describe your changes

Small but meaningful improvement. Before adding a new issue it should be also checked if the term was not already proposed but declined. 
    
