### PR TITLE
Add Urdu Localization Team Approvers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -121,7 +121,6 @@ collaborators:
   - username: Imtiaz1234
     permission: push
     
-
   # l10n es approvers
   - username: raelga
     permission: push
@@ -157,6 +156,14 @@ collaborators:
 
   - username: Krast76
     permission: push
+
+  # l10n ur approvers
+  - username: Saim-Safdar
+    permission: push
+
+  - username: waleed318
+    permission: push
+
 
 branches:
 
@@ -364,6 +371,23 @@ branches:
          - huats
          - fydrah
          - Krast76
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+      
+  # l10n branch for ur contents only
+  - name: dev-ur
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # ur approvers
+        users:
+         - Saim-Safdar
+         - waleed318
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,3 +41,6 @@
 
 # Approvers for French contents
 /content/fr/ @huats @fydrah @Krast76
+
+# Approvers for Urdu contents
+/content/ur/ @Saim-Safdar @waleed318


### PR DESCRIPTION
Signed-off-by: Seokho Son <shsongist@gmail.com>

### Based on 
 - Request for #1310
 - [Contributor-ladder: localization approvers](https://glossary.cncf.io/contributor-ladder/#localization-approvers)

### This PR add approvers for Urdu Localization

  - [x] Saim Safdar (@Saim-Safdar)
  - [x] Waleed Ahmed (@waleed318)

### Important
 - All candidates need to **leave a comment** in this PR that you understood the following policies and information. (l10n teams: please share this message to candidates)
   - [Policies for localization approvers (to be confirmed by candidates)](https://github.com/cncf/glossary/discussions/723)
   - Please understand that a candidate who does not check and confirm it, the candidate can not be an approver.
 - The l10n team approvers need to **use your permission appropriately**.
   - The approvers of l10n team will have a push permission to this repository.
It is to make l10n approvers manage (merge) PRs for l10n contributions in your development branch.
Merging a PR to the `main` branch by l10n approvers is restricted.
Even if they are possible to review a PR to the `main` branch and give an approval to the PR, they should not approve the PR. 
So, please do not approve if a PR is not related with your localization.
 - After this PR merged, the approvers will get an **github invitation** for collaborate from settings[bot] of cncf/glossary. You need to accept. Please find the invitation from Email or Github notification. It the candidate dose not accept it, maintainers cannot assign you as an approver of  dev-xx branch.

