### PR TITLE
Disable TEMPLATE from sidebar of Korean site

### DIFF
--- a/content/ko/_TEMPLATE.md
+++ b/content/ko/_TEMPLATE.md
@@ -1,6 +1,7 @@
 ---
 title: 용어 정의 템플릿
-status: Feedback Appreciated (가이드: status 값은 영어 원문과 동일하게 유지)
+status: Feedback Appreciated
+# 가이드: status 값은 영어 원문과 동일하게 유지
 category: 개념
 ---
 

--- a/content/ko/_TEMPLATE.md
+++ b/content/ko/_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 title: 용어 정의 템플릿
-status: Feedback Appreciated
+status: Feedback Appreciated (가이드: status 값은 영어 원문과 동일하게 유지)
 category: 개념
 ---
 

--- a/content/ko/_TEMPLATE.md
+++ b/content/ko/_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 title: 용어 정의 템플릿
-status: Completed
+status: Feedback Appreciated
 category: 개념
 ---
 


### PR DESCRIPTION
Signed-off-by: Seokho Son <shsongist@gmail.com>

### Describe your changes
Disable TEMPLATE from sidebar of Korean site.
Status: Completed makes the TEMPLATE item shown in the sidebar 

### Related issue number or link (ex: `resolves #issue-number`)
N/A

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco).
    
