### PR TITLE
add info about adding sign off to global git config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,5 @@
 - [ ] This PR does not contain plagiarism
   - don’t copy other people’s work unless you are quoting and contributing it to them.
 - [ ] I have signed off on all commits 
-  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco).
+  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
     


### PR DESCRIPTION
Signed-off-by: Noah Ispas (iamNoah1) <noahispas@gmail.com>

### Describe your changes
Add info about adding sign off to global git config 

### Related issue number or link (ex: `resolves #issue-number`)
none

### Checklist before opening this PR (put `x` in the checkboxes)
- [ ] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco).
    
