### PR TITLE
Spanish localization for content/en/reliability.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,5 @@
 - [ ] This PR does not contain plagiarism
   - don’t copy other people’s work unless you are quoting and contributing it to them.
 - [ ] I have signed off on all commits 
-  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco).
+  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
     

--- a/.github/workflows/check-outdated-terms.yaml
+++ b/.github/workflows/check-outdated-terms.yaml
@@ -1,0 +1,131 @@
+# This workflow will check if localized terms are outdated or not
+# by comparing English terms in the old branch and the latest branch.
+name: Check outdated terms
+on: 
+  pull_request:
+    paths:
+      - 'content/en/**.md'
+    branches:
+      - 'dev-ko' # add other branches or use wildcard 'dev-**'
+
+jobs:
+  check-outdated-terms:
+    name: Check outdated terms
+    
+    # Condition to run this workflow on the upstream repository
+    #if: github.repository == 'cncf/glossary'
+    
+    runs-on: ubuntu-latest
+    # permissions:
+    #   issues: write
+    
+    # NOTE - In this workflow, "github.base_ref" refers to the old upstream/dev-xx.
+    # NOTE - In this workflow, "github.head_ref" refers to the latest forked/dev-xx or the latest upstream/main.
+    steps:
+    - name: Set up environment variables for the target L10n team
+      shell: bash
+      run: |
+        
+        # Set L10n branch
+        L10N_BRANCH="${{github.base_ref}}"
+        echo "(DEBUG) L10N Branch: ${L10N_BRANCH}"
+        
+        # Set L10n directory and code
+        case "${L10N_BRANCH}" in
+          dev-ko)          
+          L10N_DIR="./content/ko/"
+          L10N_CODE="ko"
+          ;;
+          
+          #dev-pt)
+          #L10N_DIR="./content/pt-br/"
+          #L10N_CODE="pt"
+          #;;
+        esac
+        
+        echo "(DEBUG) L10N Directory: ${L10N_DIR}"
+        echo "(DEBUG) L10N Code: ${L10N_CODE}"
+        
+        # Set L10N_DIR and L10N_CODE as environment variables
+        # Ref: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+        echo "L10N_DIR=${L10N_DIR}" >> $GITHUB_ENV
+        echo "L10N_CODE=${L10N_CODE}" >> $GITHUB_ENV        
+    
+    - name: Checkout 
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # fetch all history for all tags and branches
+        
+    - name: Check outdated
+      id: checker
+      shell: bash
+      run: |
+        ##### DEBUG section, this will be removed later ###########
+        ls -al
+        git status
+        git branch
+        
+        # Default environment variables 
+        echo "GITHUB_REF: $GITHUB_REF"
+        echo "Extract branch: ${GITHUB_REF#refs/}"
+        
+        # `github` context information
+        echo "(DEBUG) github.ref: ${{github.ref}}"
+        echo "(DEBUG) github.head_ref: ${{github.head_ref}}"
+        echo "(DEBUG) github.base_ref: ${{github.base_ref}}"
+        echo "(DEBUG) L10N_DIR: ${L10N_DIR}"
+        echo "(DEBUG) L10N_DIR: ${{ env.L10N_DIR }}"
+        #####################################################
+        
+        # Get the lastest branch name from 'GITHUB_REF' 
+        # The latest branch can be 'upstream/main' or 'forked/dev-ko' (rebased)
+        LATEST_BRANCH=${GITHUB_REF#refs/}
+        echo "(DUBUG) LATEST_BRANCH: ${LATEST_BRANCH}"
+        
+        # Get the old branch from 'github.base_ref' 
+        # The old branch can be 'upstream/dev-ko'
+        OLD_BRANCH="origin/${{github.base_ref}}"
+        echo "(DUBUG) OLD_BRANCH: ${OLD_BRANCH}"
+        
+        # Make an output directory
+        mkdir outdated
+        
+        # Check outdated only if there is a localized term
+        # Loop files in a localization directory, which is ${L10N_DIR} (e.g., ./content/ko/)
+        echo "(DEBUG) Check outdated"
+        for FILE_PATH in $(find ${L10N_DIR} -name '*.md'); do
+            # ${MYVAR#pattern}: delete shortest match of pattern from the beginning
+            FILE_NAME="${FILE_PATH#${L10N_DIR}}" 
+            echo "(DEBUG) FILE_NAME: ${FILE_NAME}"
+            echo "(DEBUG) Localized file path: $FILE_PATH"
+            echo "(DEBUG) Original file path: ./content/en/${FILE_NAME}"
+            
+            # Actually compare between the old and lastest English terms and log diff in the file
+            if [[ -f "./content/en/${FILE_NAME}" ]]; then
+              # File exists
+              git diff ${OLD_BRANCH}..${LATEST_BRANCH} -- ./content/en/${FILE_NAME} > ./outdated/${FILE_NAME}
+            else
+              # File dose not exist (e.g, changed, renamed or removed)
+              echo "Could not find ${FILE_NAME} in content/en/" > ./outdated/${FILE_NAME}
+              echo "Need to check if it has been changed, renamed or removed" >> ./outdated/${FILE_NAME}
+            fi
+
+        done 
+        
+        echo "(DEBUG) The outdated files"
+        ls -al ./outdated
+        
+    - name: Upload output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.L10N_CODE }}-outdated-checking-result
+        path: ./outdated/
+
+#     - name: Create an issue from file    
+#       uses: peter-evans/create-issue-from-file@v4
+#       with:
+#         title: An example issue
+#         content-filepath:  ${{ steps.checker.outputs.output_path }}
+#         labels: |
+#           outdated
+#           lang/ko

--- a/.github/workflows/post-outdated-terms-report.yaml
+++ b/.github/workflows/post-outdated-terms-report.yaml
@@ -1,0 +1,130 @@
+# This workflow will post outdated terms report
+# by using data from previous workflows. 
+name: Post outdated terms report
+
+on:
+  workflow_run:
+    workflows: ["Check outdated terms"]
+    types:
+      - completed
+      
+jobs:
+  post-outdated-report:
+    name: Post outdated terms report
+    
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write 
+#       pull-requests: write
+
+    steps:    
+    - name: Show the github context
+      shell: bash
+      run: |
+        echo "(DEBUG) ParsedBranch: ${GITHUB_REF#refs/heads/}"
+        echo "(DEBUG) github: ${{ github }}"
+        echo "(DEBUG) toJSON(github):" 
+        echo '${{ toJSON(github) }}'
+        echo "(DEBUG) github.action: ${{ github.action }}"
+        echo "(DEBUG) github.action_path: ${{ github.action_path }}"
+        echo "(DEBUG) github.actor: ${{ github.actor }}"
+        echo "(DEBUG) github.base_ref: ${{ github.base_ref	}}"
+        echo "(DEBUG) github.event: ${{ github.event }}"
+        echo "(DEBUG) github.event_name: ${{ github.event_name }}"
+        echo "(DEBUG) github.event_path: ${{ github.event_path }}"
+        echo "(DEBUG) github.head_ref: ${{ github.head_ref }}"
+        echo "(DEBUG) github.job: ${{ github.job }}"
+        echo "(DEBUG) github.ref: ${{ github.ref }}"
+        echo "(DEBUG) github.repository: ${{ github.repository }}"
+        echo "(DEBUG) github.repository_owner: ${{ github.repository_owner }}"
+        echo "(DEBUG) github.run_id: ${{ github.run_id }}"
+        echo "(DEBUG) github.run_number: ${{ github.run_number }}"
+        echo "(DEBUG) github.sha: ${{ github.sha }}"
+        echo "(DEBUG) github.token: ${{ github.token }}"
+        echo "(DEBUG) github.workflow: ${{ github.workflow }}"
+        echo "(DEBUG) github.workspace: ${{ github.workspace }}"
+        
+#     NOTE - "actions/download-artifact" is not working for sharing data between workflows. 
+#     - name: Download output
+#       uses: actions/download-artifact@v3
+    - name: Download output
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        workflow: check-outdated-terms.yaml
+        workflow_conclusion: success
+        
+    - name: Set up environment variables from the output
+      shell: bash
+      run: |
+        echo "(DEBUG) Display files and directories"
+        tree
+        
+        # Set the last changed directory as the output directory
+        OUTPUT_DIR=$(ls -tp | head -1)
+        
+        # Extract L10N code from the directory name
+        # ${MYVAR%%-*}: retain the part before the first '-'
+        L10N_CODE=${OUTPUT_DIR%%-*}
+        
+        # Count outdated terms 
+        OUTDATED_TERMS_COUNT=$(ls $OUTPUT_DIR | wc -l)
+        
+        echo "(DEBUG) OUTPUT_DIR: ${OUTPUT_DIR}"
+        echo "(DEBUG) L10N_CODE: ${L10N_CODE}"
+        echo "(DEBUG) OUTDATED_TERMS_COUNT: ${OUTDATED_TERMS_COUNT}"
+        
+        # Set OUTPUT_DIR, L10N_CODE, and OUTDATED_TERMS_COUNT as environment variables
+        # Ref: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+        echo "OUTPUT_DIR=${OUTPUT_DIR}" >> $GITHUB_ENV
+        echo "L10N_CODE=${L10N_CODE}" >> $GITHUB_ENV
+        echo "OUTDATED_TERMS_COUNT=${OUTDATED_TERMS_COUNT}" >> $GITHUB_ENV
+        
+    - name: Generate a report markdown
+      if: ${{ env.OUTDATED_TERMS_COUNT > 0 }}
+      shell: bash
+      run: |
+        FILE_LIST=$(find ${OUTPUT_DIR} -name '*.md')
+        
+        # Create report.md
+        touch report.md
+        
+        # Generate markdown
+        echo "NOTICE - The following outdated terms must be resolved before the next L10n branch updates." >> report.md
+        echo "" >> report.md
+        echo "### Outdated files" >> report.md
+        
+        for FILE in ${FILE_LIST}; do 
+          FILE_NAME="${FILE#${OUTPUT_DIR}}" 
+          echo "- ${FILE_NAME}" >> report.md
+        done 
+        
+        echo "" >> report.md
+        
+        echo "### Details" >> report.md
+        
+        for FILE in ${FILE_LIST}; do 
+          FILE_NAME="${FILE#${OUTPUT_DIR}}" 
+
+          echo "Outdated file: ${FILE_NAME}" >> report.md
+          echo "" >> report.md
+          echo "\`\`\`diff" >> report.md 
+          cat ${FILE} >> report.md      
+          echo "\`\`\`" >> report.md 
+          echo "" >> report.md
+          
+        done 
+        
+        echo "The end of report"  >> report.md
+        
+    - name: Create an issue from the report
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: "[${{ env.L10N_CODE }}] A report to track update"
+        content-filepath: report.md
+        labels: |
+          outdated
+          good first issue
+          lang/${{ env.L10N_CODE }}

--- a/content/es/reliability.md
+++ b/content/es/reliability.md
@@ -9,5 +9,5 @@ tags: ["fundamentals", "", ""]
 
 Desde una perspectiva nativa a la nube, fiabilidad se refiere a qué tan bien un sistema responde ante las fallas. 
 Si tenemos un [sistema distribuido](/distributed-systems/) que continúa funcionando mientras la infraestructura cambia y los componentes individuales fallan, este es fiable. 
-Por otro lado, si falla fácilmente y operadores deben intervenir manualmente para mantenerlo en ejecución, entonces es poco confiable. 
+Por otro lado, si falla fácilmente y los operadores deben intervenir manualmente para mantenerlo en ejecución, entonces es poco confiable. 
 La meta de las [aplicaciones nativas para la nube](/cloud-native-apps/) es construir sistemas inherentemente fiables.

--- a/content/es/reliability.md
+++ b/content/es/reliability.md
@@ -1,0 +1,13 @@
+---
+title: Fiabilidad
+status: Feedback Appreciated
+category: property
+tags: ["fundamentals", "", ""]
+---
+
+## ¿Qué es?
+
+Desde una perspectiva nativa a la nube, fiabilidad se refiere a qué tan bien un sistema responde ante las fallas. 
+Si tenemos un [sistema distribuido](/distributed-systems/) que continúa funcionando mientras la infraestructura cambia y componentes indivuduales fallan, esta es fiable. 
+Por otro lado, si falla fácilmente y operadores deben intervenir manualmente para mantenerlo en ejecución, entonces es poco confiable. 
+La meta de las [aplicaciones nativas para la nube](/cloud-native-apps/) es construir sistemas inherentemente fiables.

--- a/content/es/reliability.md
+++ b/content/es/reliability.md
@@ -8,6 +8,6 @@ tags: ["fundamentals", "", ""]
 ## ¿Qué es?
 
 Desde una perspectiva nativa a la nube, fiabilidad se refiere a qué tan bien un sistema responde ante las fallas. 
-Si tenemos un [sistema distribuido](/distributed-systems/) que continúa funcionando mientras la infraestructura cambia y componentes indivuduales fallan, esta es fiable. 
+Si tenemos un [sistema distribuido](/distributed-systems/) que continúa funcionando mientras la infraestructura cambia y los componentes individuales fallan, este es fiable. 
 Por otro lado, si falla fácilmente y operadores deben intervenir manualmente para mantenerlo en ejecución, entonces es poco confiable. 
 La meta de las [aplicaciones nativas para la nube](/cloud-native-apps/) es construir sistemas inherentemente fiables.

--- a/content/es/reliability.md
+++ b/content/es/reliability.md
@@ -1,7 +1,7 @@
 ---
 title: Fiabilidad
 status: Feedback Appreciated
-category: property
+category: Propiedad
 tags: ["fundamentals", "", ""]
 ---
 

--- a/content/es/reliability.md
+++ b/content/es/reliability.md
@@ -10,4 +10,4 @@ tags: ["fundamentals", "", ""]
 Desde una perspectiva nativa a la nube, fiabilidad se refiere a qué tan bien un sistema responde ante las fallas. 
 Si tenemos un [sistema distribuido](/distributed-systems/) que continúa funcionando mientras la infraestructura cambia y los componentes individuales fallan, este es fiable. 
 Por otro lado, si falla fácilmente y los operadores deben intervenir manualmente para mantenerlo en ejecución, entonces es poco confiable. 
-La meta de las [aplicaciones nativas para la nube](/cloud-native-apps/) es construir sistemas inherentemente fiables.
+La meta de las [aplicaciones nativas para la nube](/es/cloud-native-apps/) es construir sistemas inherentemente fiables.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -53,4 +53,16 @@
 {{ else }}
 {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
+
+<!-- also include GA4 property -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T6VMPWFRDW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T6VMPWFRDW');
+</script>
+
 {{ end }}


### PR DESCRIPTION
Creating glossary document Spanish localization for content/en/reliability.md related to https://github.com/cncf/glossary/issues/1399

Signed-off-by: Irina Calvo <anairinac@gmail.com>

### Describe your changes

Creating glossary document Spanish localization for content/en/reliability.md 

### Related issue number or link (ex: `resolves #issue-number`)

Resolves #1399

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
