### PR TITLE
Update dev-it approver

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -86,7 +86,7 @@ collaborators:
   - username: fsbaraglia
     permission: push
 
-  - username: meryem-ldn
+  - username: ugho16
     permission: push
 
   - username: annalisag-spark
@@ -274,7 +274,7 @@ branches:
         # it approvers
         users:
          - fsbaraglia
-         - meryem-ldn
+         - ugho16
          - annalisag-spark
          - sistella
         teams: []

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@
 /content/de/ @iamNoah1 @DaveVentura @CathPag
 
 # Approvers for Italian contents
-/content/it/ @fsbaraglia @meryem-ldn @annalisag-spark @sistella
+/content/it/ @fsbaraglia @ugho16 @annalisag-spark @sistella
 
 # Approvers for Arabic contents
 /content/ar/ @TarekMSayed @same7ammar @AShabana @arezk84


### PR DESCRIPTION
Signed-off-by: Seokho Son <shsongist@gmail.com>

### Describe your changes
- Update dev-it approvers

### Related issue number or link
Based on the following request from the Italian team.
- https://github.com/cncf/glossary/pull/1414
- https://github.com/cncf/glossary/pull/1414#issuecomment-1298321548
  (ref: @annalisag-spark)

### This PR replace existing approver with a new approver for dev-it
  - [x] Commitment from the new approver @ugho16
  - [ ] Commitment (or lazy consensus) from the released approver @meryem-ldn

### Important
 - All new candidates need to **leave a comment** in this PR that you understood the following policies and information. (l10n teams: please share this message to candidates)
   - [Policies for localization approvers (to be confirmed by candidates)](https://github.com/cncf/glossary/discussions/723)
   - Please understand that a candidate who does not check and confirm it, the candidate can not be an approver.
 - The l10n team approvers need to **use your permission appropriately**.
   - The approvers of l10n team will have a push permission to this repository.
It is to make l10n approvers manage (merge) PRs for l10n contributions in your development branch.
Merging a PR to the `main` branch by l10n approvers is restricted.
Even if they are possible to review a PR to the `main` branch and give an approval to the PR, they should not approve the PR. 
So, please do not approve if a PR is not related with your localization.
 - After this PR merged, the approvers will get an **github invitation** for collaborate from settings[bot] of cncf/glossary. You need to accept. Please find the invitation from Email or Github notification. It the candidate does not accept it, maintainers cannot assign you as an approver of dev-xx branch.

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco).

