### PR TITLE
Change api absolute reference

### DIFF
--- a/content/en/event-streaming.md
+++ b/content/en/event-streaming.md
@@ -11,7 +11,7 @@ Picture a service broadcasting everything it does to all other services.
 Each activity taken by a service is referred to as an event, hence event streaming.
 For example, NASDAQ gets updates on stock and commodities pricing every second.
 If you had an application that monitored a specific set of stocks, you would want to receive that information in near real-time.
-Yahoo! Finance provides an [API](https://glossary.cncf.io/application-programming-interface/) that pulls from NASDAQ and sends (or streams) the information (or events) from their application to any application that subscribes to it.
+Yahoo! Finance provides an [API](/application-programming-interface/) that pulls from NASDAQ and sends (or streams) the information (or events) from their application to any application that subscribes to it.
 The data being sent as well as the changes in that data (stock prices) are the events while the process of delivering them to an application is event streaming.
 
 ## Problem it addresses


### PR DESCRIPTION
### Describe your changes

The Event streaming definition contains an absolute reference to the API term, this exception doesn't match with the rest of the terms.

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
