### PR TITLE
Enable labeler to non-korean languages

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,9 @@ on:
     types: [opened]
     paths:
       - 'content/**.md'
+    branches:
+      - 'main'
+      - 'dev-**'      
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,6 @@ on:
     types: [opened]
     paths:
       - 'content/**.md'
-    branches:
-      - 'dev-ko'
 
 jobs:
   triage:


### PR DESCRIPTION
### Describe your changes

The labeler task helps to organize PR based on the folder where the changes happen. This logic needs to be applied to all languages.

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
