### PR TITLE
add Baris as german loc approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@
 /content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava
 
 # Approvers for German contents
-/content/de/ @iamNoah1 @DaveVentura @CathPag
+/content/de/ @iamNoah1 @DaveVentura @CathPag @bcubk
 
 # Approvers for Italian contents
 /content/it/ @fsbaraglia @meryem-ldn @annalisag-spark @sistella


### PR DESCRIPTION
Signed-off-by: Noah Ispas (iamNoah1) <noahispas@gmail.com>

### Describe your changes

Add @bcubk as an approver for german content. 

**Important**
All candidates need to leave a comment that you understood overall policy.
The l10n team approvers need to use your permission appropriately.
The approvers of l10n team will have a push permission to this repository.
It is to make l10n approvers manage (merge) PRs for l10n contributions in your development branch.
Merging a PR to the main branch by l10n approvers is restricted.
Even if they are possible to review a PR to the main branch and give an approval to the PR, they should not approve the PR.
So, please do not approve if a PR is not related with your localization.
After this PR merged, the approvers will get an github invitation for collaborate from settings[bot] of cncf/glossary. You need to accept.