### PR TITLE
Adding ssl to the wordlist

### DIFF
--- a/content/es/.wordlist.txt
+++ b/content/es/.wordlist.txt
@@ -181,6 +181,7 @@ service
 Slack
 sobreescriba
 Spanish
+ssl
 stack
 Started
 status


### PR DESCRIPTION
Signed-off-by: Vasu Singh <vasucp1207@gmail.com>

### Describe your changes
Adding new word *ssl* to the wordlist


### Related issue number or link https://github.com/cncf/glossary/pull/1499#issuecomment-1336250661


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
