### PR TITLE
Deprecating debugging

### DIFF
--- a/content/en/debugging.md
+++ b/content/en/debugging.md
@@ -1,6 +1,6 @@
 ---
 title: Debugging
-status: Completed
+status: Deprecated
 category: concept
 tags: ["application", "methodology", ""]
 ---


### PR DESCRIPTION
Oops, we said we would deprecate but looks like I forgot to add it to the PR. 

Signed-off-by: Catherine Paganini <74001907+CathPag@users.noreply.github.com>

### Describe your changes


### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [ x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [ x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
