### PR TITLE
fixed broken links

### DIFF
--- a/content/en/contribute/_index.md
+++ b/content/en/contribute/_index.md
@@ -31,16 +31,16 @@ Go to the [Glossary GitHub repo issues](https://github.com/cncf/glossary/issues)
 There you'll see a list of all issues. You can filter by label (e.g. English language, help needed, good first issue). 
 Note that you'll need a GitHub account to do any of this.
 
-![Issue and labels](/images/how-to/issue-and-labels.png)
+![Issue and labels](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/issue-and-labels.png)
 
 Make sure the term you are interested in is not already assigned to someone. 
 Here you can see that the first three terms are available while the next term has already been assigned.
 
-![assigning a term](/images/how-to/howto-04.png)
+![assigning a term](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-04.png)
 
 Once you found a term you want to work on, say so in the issue. Click on it and add a comment.
 
-![Claiming an issue](/images/how-to/claiming-an-issue.png)
+![Claiming an issue](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/claiming-an-issue.png)
 
 Additionally, please also join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel on the CNCF Slack and 
 let the maintainers know that you've raised an issue for a new term 
@@ -67,11 +67,11 @@ And please make sure to read the [Style Guide](/style-guide/) before getting sta
 
 Go to the [Glossary GitHub repo](https://github.com/cncf/glossary/issues) issues and click on "New issue".
 
-![issues](/images/how-to/howto-01.png)
+![issues](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-01.png)
 
 You'll see a variety of templates. To propose a new term in English, select "Request to add a new term (English)".
 
-![templates](/images/how-to/english-issue-template.jpg)
+![templates](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/english-issue-template.jpg)
 
 Add the word you're suggesting, answer the two questions below, check the checkboxes, and hit "Submit new issue".
 If you're just proposing a new term, you're done! To work on it, follow the next steps.
@@ -96,23 +96,23 @@ As stated in the style guide, we highly recommend starting with a Google or Word
 
 Once the term is ready to submit, go to content (under code)…
 
-![content](/images/how-to/howto-05.png)
+![content](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-05.png)
 
 …then "en" (or the language you are submitting for)…
 
-![language folder](/images/how-to/howto-06.png)
+![language folder](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-06.png)
 
 …and select `_TEMPLATE.md`
 
-![template](/images/how-to/howto-07.png)
+![template](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-07.png)
 
 Copy the content…
 
-![copy content](/images/how-to/howto-08.png)
+![copy content](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-08.png)
 
 …and go back to the "en" folder. Hit "Add file" and select "Create new file".
 
-![create new file](/images/how-to/howto-09.png)
+![create new file](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-09.png)
 
 Add the term name in the URL (no capitalization, no spaces, no parentheses, and use hyphens to separate words)
 and .md at the end (note: if your preview doesn't work, you probably forgot to add .md at the end).
@@ -122,21 +122,21 @@ Note that GitHub uses markdown to format the text (e.g., hyperlink, bold, italic
 Please refer to this [markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/).
 To verify you've used markdown as intended, go to "Preview".
 
-![finalize term](/images/how-to/howto-10.png)
+![finalize term](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-10.png)
 
 Scroll down and name the new commit file when you are ready to submit. 
 You are now about to commit the term to your own branch. 
 Submitting a PR requires one more step. Hit "Commit new file" and…
 
-![commit new file](/images/how-to/howto-11.png)
+![commit new file](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-11.png)
 
 …now you're creating an PR:
 
-![create a pr](/images/how-to/howto-12.png)
+![create a pr](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-12.png)
 
 You should now see your PR under "Pull requests".
 
-![prs](/images/how-to/howto-13.png)
+![prs](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-13.png)
 
 ## Update an existing term {#update-an-existing-term}
 
@@ -146,17 +146,17 @@ To update an existing term, you can either suggest a change via an issue or go a
 
 If you want to flag a problem with a term but don't know how or want to fix it yourself, click on "Report issue".
 
-![report issue](/images/how-to/howto-14.png)
+![report issue](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-14.png)
 
 This will directly open an issue. Please elaborate on which change is needed and why. Hit submit, and that's it. 
 
-![submit issue](/images/how-to/howto-15.png)
+![submit issue](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-15.png)
 
 ### Update a term directly {#update-a-term-directly}
 
 To change a term directly, go to "Edit this page".
 
-![edit this page](/images/how-to/howto-16.png)
+![edit this page](https://github.com/withgaurav/glossary/blob/main/static/images/how-to/howto-16.png)
 
 This will open the term's GitHub page. Make your changes and submit a PR. 
 Please refer to "Submitting a new term" above for a detailed description (jump to the section that speaks about markdown).


### PR DESCRIPTION
Signed-off-by: Gaurav Shukla <gaurav.shukla.gs48@gmail.com>

### Describe your changes
I've fixed broken links in _index.md english language 

### Related issue number or link: resolves #1547


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
