### PR TITLE
Fix taxonomy issues

### DIFF
--- a/content/en/containers-as-a-service.md
+++ b/content/en/containers-as-a-service.md
@@ -2,6 +2,7 @@
 title: Containers as a Service
 status: Deprecated
 category: Technology
+draft: true
 tags: ["platform", "", ""]
 ---
 

--- a/content/en/database-as-a-service.md
+++ b/content/en/database-as-a-service.md
@@ -2,6 +2,7 @@
 title: Database as a Service (DBaaS)
 status: Deprecated
 category: Technology
+draft: true
 tags: ["", "", ""]
 ---
 

--- a/content/en/debugging.md
+++ b/content/en/debugging.md
@@ -2,6 +2,7 @@
 title: Debugging
 status: Deprecated
 category: concept
+draft: true
 tags: ["application", "methodology", ""]
 ---
 

--- a/content/en/firewall.md
+++ b/content/en/firewall.md
@@ -1,6 +1,7 @@
 ---
 title: Firewall
 status: Deprecated
+draft: true
 category: Technology
 tags: ["", "", ""]
 ---

--- a/content/en/firewall.md
+++ b/content/en/firewall.md
@@ -2,7 +2,7 @@
 title: Firewall
 status: Deprecated
 category: Technology
-tags: ["Deprecated", "", ""]
+tags: ["", "", ""]
 ---
 
 ## What it is

--- a/content/en/managed-services.md
+++ b/content/en/managed-services.md
@@ -1,6 +1,7 @@
 ---
 title: Managed services
 status: Deprecated
+draft: true
 category: Technology
 tags: ["", "", ""]
 ---

--- a/content/en/platform-as-a-service.md
+++ b/content/en/platform-as-a-service.md
@@ -2,7 +2,7 @@
 title: Platform as a Service (PaaS)
 status: Deprecated
 category: Technology
-tags: ["fundamentals", "platform", ""]
+tags: ["fundamental", "platform", ""]
 ---
 
 ## What it is

--- a/content/en/platform-as-a-service.md
+++ b/content/en/platform-as-a-service.md
@@ -2,6 +2,7 @@
 title: Platform as a Service (PaaS)
 status: Deprecated
 category: Technology
+draft: true
 tags: ["fundamental", "platform", ""]
 ---
 

--- a/content/en/software-as-a-service.md
+++ b/content/en/software-as-a-service.md
@@ -2,6 +2,7 @@
 Title: Software as a Service (SaaS)
 Status: Deprecated
 Category: Technology
+draft: true
 tags: ["fundamental", "platform", ""]
 ---
 

--- a/content/en/software-as-a-service.md
+++ b/content/en/software-as-a-service.md
@@ -2,7 +2,7 @@
 Title: Software as a Service (SaaS)
 Status: Deprecated
 Category: Technology
-tags: ["fundamentals", "platform", ""]
+tags: ["fundamental", "platform", ""]
 ---
 
 ## What it is

--- a/content/en/version-control.md
+++ b/content/en/version-control.md
@@ -2,6 +2,7 @@
 title: Version Control
 status: Deprecated
 category: Technology
+draft: true
 tags: ["methodology", "", ""]
 ---
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,7 +26,6 @@
 {{ end }}
 
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,6 +1,11 @@
-{{ if .Path }}
-{{ if not ( or ( in .Path "search" ) ( in .Path "tags" ) ) }}
-  {{ $pathFormatted := replace .Path "\\" "/" }}
+{{ $path := "" }}
+{{ with .File }}
+  {{ $path = .Path }}
+{{ else }}
+  {{ $path = .Path }}
+{{ end }}
+{{ if not ( or ( in $path "search" ) ( in $path "tags" ) ) }}
+  {{ $pathFormatted := replace $path "\\" "/" }}
   {{ $gh_repo := ($.Param "github_repo") }}
   {{ $gh_url := ($.Param "github_url") }}
   {{ $gh_subdir := ($.Param "github_subdir") }}
@@ -37,5 +42,4 @@
     <a id="print" href="{{ .Permalink | safeURL }}"><i class="fa fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
   {{ end }}
   </div>
-{{ end }}
 {{ end }}

--- a/layouts/partials/taxonomy_terms_cloud.html
+++ b/layouts/partials/taxonomy_terms_cloud.html
@@ -10,7 +10,7 @@
       {{ end }}
       <ul class="tax-terms">
         {{ range $taxonomy }}
-          <li><a class="tax-term" href="{{ .Page.RelPermalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ .Page.Title }}</span></a><span class="taxonomy-count">({{ .Count }})</span></li>
+          <li><a class="tax-term" href="{{ .Page.RelPermalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ title .Page.Title }}</span></a><span class="taxonomy-count">({{ .Count }})</span></li>
         {{ end }}
       </ul>
     </div>


### PR DESCRIPTION
Fixes a few small issues with the current taxonomies:
- `draft: true` needs to be added to terms that are no longer "Completed" such as those that are now "Deprecated"; this removes them from the tag count on [this page](https://glossary.cncf.io/tags/) and will remove them from the google search index
- changed 2 instances of the "fundamentals" tag to be "fundamental" which is more common
- removed a "Deprecated" tag that was only used in one instance
- made terms title-case on [this page](https://glossary.cncf.io/tags/) to agree with all other instances
- reference to google_news internal template is removed since it is deprecated
- new way of getting .Path is implemented to prepare for upcoming change in Hugo
