### PR TITLE
Get active indicators working on topnav

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -4,9 +4,14 @@
 	padding-left: 0;
 	padding-right: 0;
 	@media (min-width: 768px) {
+		padding-top: 15px;
+		padding-bottom: 15px;
 		min-height: 5rem;
-		margin-bottom: 3rem;
-		padding: 0;
+		padding: 0 2rem 0 0;
+	}
+
+	@media (max-width: 500px) {
+		padding-bottom: 0;
 	}
 	&:after {
 		background: linear-gradient(180deg, rgba(0, 0, 0, 0.1), transparent);
@@ -17,15 +22,14 @@
 		width: 100%;
 		z-index: 1;
 	}
-
+	// Logo area.
 	.navbar-brand {
 		@media (min-width: 768px) {
-			padding-top: 0.5rem;
+			padding-top: 0;
 			padding-bottom: 0rem;
-			margin-left: 1rem;
+			margin-left: 2rem;
 		}
 		.navbar-logo {
-			margin-bottom: 10px;
 			display: block;
 			svg {
 				height: 40px;
@@ -33,10 +37,12 @@
 		}
 	}
 
+	// Main nav bar.
 	.td-navbar-nav-scroll {
 		margin-top: 0;
-		margin-left: -0.5rem;
-		margin-right: -0.5rem;
+		@media (min-width: 500px) {
+			overflow: visible;
+		}
 		.navbar-nav {
 			padding-bottom: 0;
 			display: flex;
@@ -55,15 +61,51 @@
 				background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
 				background-attachment: local, local, scroll, scroll;
 			}
+
+			@media (min-width: 500px) {
+				overflow: visible;
+			}
+
 			.nav-item {
 				.nav-link {
 					font-weight: 600;
-					transition: color 0.25s ease-in;
+					padding-right: 0;
+					padding-left: 0;
 					@media (max-width: 500px) {
 						padding: 0 !important;
 					}
 					@media (min-width: 768px) {
 						letter-spacing: 0.02em;
+					}
+					span {
+						position: relative;
+						@media (min-width: 501px) {
+							padding-left: 6px;
+							padding-right: 6px;
+						}
+						&:after {
+							content: '';
+							position: absolute;
+							left: 0;
+							right: 0;
+							bottom: -32px;
+							@media (max-width: 991px) {
+								bottom: -35px;
+							}
+							@media (max-width: 767px) {
+								bottom: -23px;
+							}
+							@media (max-width: 500px) {
+								bottom: -12px;
+							}
+							height: 4px;
+							display: block;
+							width: 100%;
+							background-color: transparent;
+						}
+					}
+					&.active span:after {
+						background-color: #99ebff;
 					}
 				}
 				// Topnav dropdown.
@@ -75,6 +117,14 @@
 						&:focus {
 							color: $black;
 							text-decoration: none;
+						}
+					}
+				}
+				// Adds some spacing to the end of the mobile menu when it overflows.
+				@media (max-width: 500px) {
+					&:last-child {
+						.nav-link span {
+							margin-right: 20px;
 						}
 					}
 				}


### PR DESCRIPTION
Inserts an active indicator on topnav elements to align with other CNCF sites like [Contribute](https://contribute.cncf.io/maintainers/):

<img width="1230" alt="Screen Shot 2023-01-04 at 12 54 21 PM" src="https://user-images.githubusercontent.com/463160/210492797-996e09b4-8536-4bc7-97da-9acdba784427.png">
