### PR TITLE
Correct 2 URLs

### DIFF
--- a/content/en/kubernetes.md
+++ b/content/en/kubernetes.md
@@ -10,14 +10,14 @@ tags: ["infrastructure", "fundamental", ""]
 Kubernetes, often abbreviated as K8s, is an open source container orchestrator. 
 It automates the lifecycle of containerized applications on modern infrastructures, functioning as a "datacenter operating system" that manages applications across a [distributed system](/distributed-systems/).
 
-Kubernetes schedules [containers](container/) across [nodes](/nodes/) in a [cluster](/cluster/), bundling several infrastructure resources such as load balancer, persistent storage, etc. to run containerized applications.
+Kubernetes schedules [containers](/container/) across [nodes](/nodes/) in a [cluster](/cluster/), bundling several infrastructure resources such as load balancer, persistent storage, etc. to run containerized applications.
 
 Kubernetes enables automation and extensibility, allowing users to deploy applications declaratively (see below) in a reproducible way. 
 Kubernetes is extensible via its [API](/application-programming-interface/), allowing experienced Kubernetes practitioners to leverage its automation capabilities according to their needs.
 
 ## Problem it addresses
 
-Infrastructure automation and declarative configuration management have been important concepts for a long time, but they have become more pressing as [cloud computing](cloud-computing/) has gained popularity. 
+Infrastructure automation and declarative configuration management have been important concepts for a long time, but they have become more pressing as [cloud computing](/cloud-computing/) has gained popularity. 
 As demand for compute resources increases and organizations need to provide more operational capabilities with fewer engineers, new technologies and working methods are required to meet that demand. 
 
 ## How it helps


### PR DESCRIPTION
MD code for containers and cloud-computing has wrong address (missing a / in each one).

Signed-off-by: Adail Horst <the.spaww@gmail.com>

### Describe your changes


### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [X ] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [X ] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
