### PR TITLE
Fix container and cloud-computing links in Kubernetes term

### DIFF
--- a/content/en/kubernetes.md
+++ b/content/en/kubernetes.md
@@ -10,14 +10,14 @@ tags: ["infrastructure", "fundamental", ""]
 Kubernetes, often abbreviated as K8s, is an open source container orchestrator. 
 It automates the lifecycle of containerized applications on modern infrastructures, functioning as a "datacenter operating system" that manages applications across a [distributed system](/distributed-systems/).
 
-Kubernetes schedules [containers](container/) across [nodes](/nodes/) in a [cluster](/cluster/), bundling several infrastructure resources such as load balancer, persistent storage, etc. to run containerized applications.
+Kubernetes schedules [containers](/container/) across [nodes](/nodes/) in a [cluster](/cluster/), bundling several infrastructure resources such as load balancer, persistent storage, etc. to run containerized applications.
 
 Kubernetes enables automation and extensibility, allowing users to deploy applications declaratively (see below) in a reproducible way. 
 Kubernetes is extensible via its [API](/application-programming-interface/), allowing experienced Kubernetes practitioners to leverage its automation capabilities according to their needs.
 
 ## Problem it addresses
 
-Infrastructure automation and declarative configuration management have been important concepts for a long time, but they have become more pressing as [cloud computing](cloud-computing/) has gained popularity. 
+Infrastructure automation and declarative configuration management have been important concepts for a long time, but they have become more pressing as [cloud computing](/cloud-computing/) has gained popularity. 
 As demand for compute resources increases and organizations need to provide more operational capabilities with fewer engineers, new technologies and working methods are required to meet that demand. 
 
 ## How it helps


### PR DESCRIPTION

Added "/" to container and cloud-computing links. Because without "/" the page is forwarded to kubernetes/container/ and kubernetes/cloud-computing/ address.

- [x] This PR does not contain plagiarism
- [x] I have signed off on all commits 
    
