### PR TITLE
Update the check outdated terms workflow

### DIFF
--- a/.github/workflows/check-outdated-terms.yaml
+++ b/.github/workflows/check-outdated-terms.yaml
@@ -3,14 +3,19 @@
 name: Check outdated terms
 on: 
   pull_request:
-    paths:
-      - 'content/en/**.md'
     branches:
       - 'dev-ko' # add other branches or use wildcard 'dev-**'
+    paths:
+      - 'content/en/**.md'
 
 jobs:
   check-outdated-terms:
     name: Check outdated terms
+
+    # if: contains(fromJSON('["dev-ko", "dev-xx"]'), github.base_ref) 
+    # Ref: https://docs.github.com/en/actions/learn-github-actions/expressions
+
+    if: github.base_ref == 'dev-ko'
     
     # Condition to run this workflow on the upstream repository
     #if: github.repository == 'cncf/glossary'
@@ -30,6 +35,9 @@ jobs:
         L10N_BRANCH="${{github.base_ref}}"
         echo "(DEBUG) L10N Branch: ${L10N_BRANCH}"
         
+        # Set output direcory
+        OUTPUT_DIR="./outdated"
+        
         # Set L10n directory and code
         case "${L10N_BRANCH}" in
           dev-ko)          
@@ -46,10 +54,11 @@ jobs:
         echo "(DEBUG) L10N Directory: ${L10N_DIR}"
         echo "(DEBUG) L10N Code: ${L10N_CODE}"
         
-        # Set L10N_DIR and L10N_CODE as environment variables
+        # Set L10N_DIR, L10N_CODE, and OUTPUT_DIR as environment variables
         # Ref: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
         echo "L10N_DIR=${L10N_DIR}" >> $GITHUB_ENV
-        echo "L10N_CODE=${L10N_CODE}" >> $GITHUB_ENV        
+        echo "L10N_CODE=${L10N_CODE}" >> $GITHUB_ENV
+        echo "OUTPUT_DIR=${OUTPUT_DIR}" >> $GITHUB_ENV
     
     - name: Checkout 
       uses: actions/checkout@v3
@@ -88,38 +97,59 @@ jobs:
         echo "(DUBUG) OLD_BRANCH: ${OLD_BRANCH}"
         
         # Make an output directory
-        mkdir outdated
+        if [[ ! -e $OUTPUT_DIR ]]; then
+            mkdir $OUTPUT_DIR
+        elif [[ ! -d $OUTPUT_DIR ]]; then
+            echo "$OUTPUT_DIR already exists but is not a directory" 1>&2
+        fi
         
         # Check outdated only if there is a localized term
         # Loop files in a localization directory, which is ${L10N_DIR} (e.g., ./content/ko/)
         echo "(DEBUG) Check outdated"
-        for FILE_PATH in $(find ${L10N_DIR} -name '*.md'); do
-            # ${MYVAR#pattern}: delete shortest match of pattern from the beginning
-            FILE_NAME="${FILE_PATH#${L10N_DIR}}" 
+        for L10N_FILE_PATH in $(find ${L10N_DIR} -name '*.md'); do
+            echo "(DEBUG) L10N_FILE_PATH: ${L10N_FILE_PATH}"      
+
+            # Note - extracting a pattern-based substring (https://stackoverflow.com/a/19482947)      
+            FILE_PATH="${L10N_FILE_PATH#${L10N_DIR}}"
+            FILE_DIR=$(dirname ${FILE_PATH})
+            FILE_NAME=$(basename ${FILE_PATH})
+            
+            echo "(DEBUG) FILE_PATH: ${FILE_PATH}"
+            echo "(DEBUG) FILE_DIR: ${FILE_DIR}"
             echo "(DEBUG) FILE_NAME: ${FILE_NAME}"
-            echo "(DEBUG) Localized file path: $FILE_PATH"
-            echo "(DEBUG) Original file path: ./content/en/${FILE_NAME}"
+            echo "(DEBUG) Localized file path: $L10N_FILE_PATH"
+            echo "(DEBUG) Original file path: ./content/en/${FILE_PATH}"
+
+            # Create subdirectories
+            mkdir -p ${OUTPUT_DIR}/${FILE_DIR}
             
             # Actually compare between the old and lastest English terms and log diff in the file
-            if [[ -f "./content/en/${FILE_NAME}" ]]; then
+            if [[ -f "./content/en/${FILE_PATH}" ]]; then
               # File exists
-              git diff ${OLD_BRANCH}..${LATEST_BRANCH} -- ./content/en/${FILE_NAME} > ./outdated/${FILE_NAME}
-            else
-              # File dose not exist (e.g, changed, renamed or removed)
-              echo "Could not find ${FILE_NAME} in content/en/" > ./outdated/${FILE_NAME}
-              echo "Need to check if it has been changed, renamed or removed" >> ./outdated/${FILE_NAME}
-            fi
+              # Check changes
+              git diff ${OLD_BRANCH}..${LATEST_BRANCH} -- ./content/en/${FILE_PATH} > temp.diff
 
+              if [[ -s "temp.diff" ]]; then
+                echo "(DEBUG) ${FILE_PATH} is outdated."
+                mv temp.diff ${OUTPUT_DIR}/${FILE_PATH}
+              fi
+
+            else
+              echo "(DEBUG) ${FILE_PATH} dose not exist."
+              # File dose not exist (e.g, changed, renamed or removed)
+              echo "Could not find ${FILE_PATH} in content/en/" > ${OUTPUT_DIR}/${FILE_PATH}
+              echo "Need to check if it has been changed, renamed or removed" >> ${OUTPUT_DIR}/${FILE_PATH}
+            fi
         done 
         
         echo "(DEBUG) The outdated files"
-        ls -al ./outdated
+        ls -al ${OUTPUT_DIR}
         
     - name: Upload output
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.L10N_CODE }}-outdated-checking-result
-        path: ./outdated/
+        path: ${{ env.OUTPUT_DIR }}/
 
 #     - name: Create an issue from file    
 #       uses: peter-evans/create-issue-from-file@v4


### PR DESCRIPTION
Signed-off-by: Yunkon Kim <hermitkim1@gmail.com>

### Describe your changes
- This PR will update the workflow to check outdated terms to fix bugs. (check-outdated-terms.yaml)
   - Fix the failure to create a diff log file
   - Avoid creating empty diff log files
   - Check if the branch name is 'dev-ko' (currently it is testing)
 
### Related issue number or link (ex: `resolves #issue-number`)
#1682, #1360

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
