### PR TITLE
Fix dev-es stale GH workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+name: Stale label
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at 12am UTC
+  push:
+    branches:
+      - dev-es
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Run stale task to label inactive issues
+    timeout-minutes: 1 # Default: 360 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue/PR is stale because it has been inactive for 60 days. This issue/PR will be closed automatically with additional 20 days of inactivity. If an update/comment occur on stale issue/PR, the stale label will be removed and the timer will restart. Closed issue/PR can be reopened if necessary.'
+          stale-pr-message: 'This issue/PR is stale because it has been inactive for 60 days. This issue/PR will be closed automatically with additional 20 days of inactivity. If an update/comment occur on stale issue/PR, the stale label will be removed and the timer will restart. Closed issue/PR can be reopened if necessary.'
+          exempt-issue-labels: 'maintainers, lang/es'
+          exempt-pr-labels: 'maintainers'
+          stale-pr-label: 'stale'
+          stale-issue-label: 'stale'
+          days-before-stale: 60
+          days-before-close: 20
+          only-labels: 'lang/es'
+          close-issue-label: 'close/stale'
+          close-pr-label: 'close/stale' # Add the label for mainteiners track the close pr labels.


### PR DESCRIPTION
### Describe your changes
This change fixes the syntax of stale workflow, removing the double quotes from the name and upgrades the version number of the task

### Related issue number or link (ex: `resolves #issue-number`)
NA

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
