### PR TITLE
[ko] Deprecate Korean container-as-a-service.md

### DIFF
--- a/content/ko/container-as-a-service.md
+++ b/content/ko/container-as-a-service.md
@@ -1,6 +1,6 @@
 ---
 title: 서비스형 컨테이너 (Containers as a Service)
-status: Completed
+status: Deprecated
 category: 기술
 tags: ["플랫폼", "", ""]
 ---


### PR DESCRIPTION
### Describe your changes
https://github.com/cncf/glossary/blob/main/content/en/containers-as-a-service.md has been deprecated. by https://github.com/cncf/glossary/pull/1449
This PR deprecates the Korean version too.

### Related issue number or link (ex: `resolves #issue-number`)
None

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
