### PR TITLE
[ko] Deprecated Korean debugging.md

### DIFF
--- a/content/ko/debugging.md
+++ b/content/ko/debugging.md
@@ -1,7 +1,8 @@
 ---
 title: 디버깅 (Debugging)
-status: Completed
+status: Deprecated
 category: 개념
+draft: true
 tags: ["애플리케이션", "방법론", ""]
 ---
 


### PR DESCRIPTION
### Describe your changes
https://github.com/cncf/glossary/blob/main/content/en/debugging.md. 
by https://github.com/cncf/glossary/pull/1449

This PR deprecates the Korean version too.

### Related issue number or link (ex: `resolves #issue-number`)
None

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
