### PR TITLE
Add initial approvers for Traditional Chinese

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -143,7 +143,7 @@ collaborators:
   - username: 92nqb
     permission: push
 
-  # l10n zh approvers
+  # l10n zh-ch approvers
   - username: hanyuancheung
     permission: push
 
@@ -174,6 +174,13 @@ collaborators:
     permission: push
 
   - username: waleed318
+    permission: push
+
+  # l10n zh-tw approvers
+  - username: pichuang
+    permission: push
+
+  - username: ydFu
     permission: push
 
 
@@ -352,7 +359,7 @@ branches:
       enforce_admins: null
       required_linear_history: null
 
-  # l10n branch for zh contents only
+  # l10n branch for zh-ch contents only
   - name: dev-zh
     protection:
       required_pull_request_reviews:
@@ -361,7 +368,7 @@ branches:
       required_status_checks: null
       restrictions:
         apps: []
-        # zh approvers
+        # zh-ch approvers
         users:
          - hanyuancheung
          - Jacob953
@@ -402,6 +409,23 @@ branches:
         users:
          - Saim-Safdar
          - waleed318
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for zh-tw contents only
+  - name: dev-tw
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # zh-tw approvers
+        users:
+         - pichuang
+         - ydFu
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -143,7 +143,7 @@ collaborators:
   - username: 92nqb
     permission: push
 
-  # l10n zh-ch approvers
+  # l10n zh-cn approvers
   - username: hanyuancheung
     permission: push
 
@@ -359,7 +359,7 @@ branches:
       enforce_admins: null
       required_linear_history: null
 
-  # l10n branch for zh-ch contents only
+  # l10n branch for zh-cn contents only
   - name: dev-zh
     protection:
       required_pull_request_reviews:
@@ -368,7 +368,7 @@ branches:
       required_status_checks: null
       restrictions:
         apps: []
-        # zh-ch approvers
+        # zh-cn approvers
         users:
          - hanyuancheung
          - Jacob953

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,7 +36,7 @@
 # Approvers for Spanish contents
 /content/es/ @raelga @ramrodo @electrocucaracha @krol3 @92nqb
 
-# Approvers for Chinese contents
+# Approvers for Simplified Chinese contents
 /content/zh-cn/ @hanyuancheung @Jacob953 @Rocksnake @Submarinee
 
 # Approvers for French contents
@@ -44,3 +44,6 @@
 
 # Approvers for Urdu contents
 /content/ur/ @Saim-Safdar @waleed318
+
+# Approvers for Traditional Chinese contents
+/content/zh-tw/ @pichuang @ydFu


### PR DESCRIPTION
### Describe your changes
Add initial approvers for Traditional Chinese based on the initiation request (#1987)
- [A] Ader Fu (@ydFu)
- [A] Phil Huang (@pichuang)

### Related issue number or link (ex: `resolves #issue-number`)
#1987

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
