### PR TITLE
Update permission and add initial approvers for Japanese

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -31,10 +31,10 @@ collaborators:
     permission: admin
   
   - username: jihoon-seo
-    permission: maintain
+    permission: admin
 
   - username: iamNoah1
-    permission: maintain  
+    permission: admin
   
   - username: thetwopct
     permission: push
@@ -44,11 +44,10 @@ collaborators:
   
 
   # Localization approvers
+  
   # l10n ko approvers
   # Note: seokho-son is both Maintainer (maintain) and Korean approver (push)
   # Note: jihoon-seo is both Maintainer (maintain) and Korean approver (push)
-  - username: Eviekim
-    permission: push
 
   - username: yunkon-kim
     permission: push
@@ -183,6 +182,15 @@ collaborators:
   - username: ydFu
     permission: push
 
+  # l10n ja approvers
+  - username: inductor
+    permission: push
+
+  - username: kaitoii11
+    permission: push
+
+  - username: naonishijima
+    permission: push
 
 branches:
 
@@ -219,7 +227,6 @@ branches:
         # Ko approvers
         users:
          - seokho-son
-         - Eviekim
          - jihoon-seo
          - yunkon-kim
         teams: []
@@ -429,3 +436,22 @@ branches:
         teams: []
       enforce_admins: null
       required_linear_history: null
+
+  # l10n branch for ja contents only
+  - name: dev-ja
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # ja approvers
+        users:
+         - inductor
+         - kaitoii11
+         - naonishijima
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+      


### PR DESCRIPTION
### Describe your changes
1. Add initial approvers for Japanese Localization based on the initiation request (#1422)
- [A] Kohei Ota (@inductor)
- [A] Nao Nishijima(@naonishijima)
- [A] Kaito (@kaitoii11)

2. Change permission for @iamNoah1 @jihoon-seo from maintain to admin so that the maintainers can merge a PR related with branches 

3. Remove inactive localization approvers


### Related issue number or link (ex: `resolves #issue-number`)
#1422

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
