### PR TITLE
Refactored padding properties to shorthand.

### DIFF
--- a/assets/scss/_cookie-banner.scss
+++ b/assets/scss/_cookie-banner.scss
@@ -17,10 +17,7 @@ $cookie-banner-bg: #bff3ff;
 	letter-spacing: 0.02em;
 	font-size: 13px;
 	font-family: $font-primary;
-	padding-top: 35px;
-	padding-left: 25px;
-	padding-right: 25px;
-	padding-bottom: 25px;
+	padding: 35px 25px 25px 25px;
 	@media (min-width: 600px) {
 		font-size: 16px;
 	}


### PR DESCRIPTION
### Refactored padding properties to shorthand property

This PR introduces a refactoring of the padding properties to a shorthand format in order to improve code readability and maintainability. 
The previous individual padding properties (padding-right, padding-left, padding-top, padding-bottom) have been replaced with a single shorthand property (padding) in the relevant SCSS rules.
 
### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
