### PR TITLE
Adding nate-double-u to list of en approvers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -41,7 +41,8 @@ collaborators:
 
   # English approvers (approver for all files in repository)
 
-  
+  - username: nate-double-u
+    permission: admin
 
   # Localization approvers
   
@@ -211,6 +212,7 @@ branches:
          - seokho-son
          - iamNoah1
          - jihoon-seo
+         - nate-double-u
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,11 +6,14 @@
 
 # These owners will be default owners for everything in this repository.
 # These owners consist of Maintainers and English approvers.
-* @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo
+* @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u
 
 
 # These are the owners (approvers) for localization contents
 # in each `/content/language/` directory.
+
+# Approvers for English content
+/content/en/ @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u
 
 # Approvers for Korean contents
 /content/ko/ @seokho-son @Eviekim @jihoon-seo @yunkon-kim


### PR DESCRIPTION
### Describe your changes

Adding myself to the en reviewers group.
Adding myself to the system that (i think) automatically sets reviewers for lang/en PRs

### Related issue number or link (ex: `resolves #issue-number`)

n/a

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
