### PR TITLE
Update `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,44 +9,52 @@
 * @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u
 
 
-# These are the owners (approvers) for localization contents
-# in each `/content/language/` directory.
-
 # Approvers for English content
 /content/en/ @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u
 
-# Approvers for Korean contents
-/content/ko/ @seokho-son @Eviekim @jihoon-seo @yunkon-kim
 
-# Approvers for Portuguese contents
-/content/pt-br/ @edsoncelio @brunoguidone @jessicalins @MrErlison
+# These are the owners (approvers) for localization contents
+# in each `/content/language/` directory.
 
-# Approvers for Hindi contents
-/content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava
-
-# Approvers for German contents
-/content/de/ @iamNoah1 @DaveVentura @CathPag @bcubk
-
-# Approvers for Italian contents
-/content/it/ @fsbaraglia @ugho16 @annalisag-spark @sistella
 
 # Approvers for Arabic contents
 /content/ar/ @TarekMSayed @same7ammar @AShabana @arezk84
 
 # Approvers for Bengali contents
-/content/bn/ @mitul3737 @Mouly22 @ikramulkayes @Imtiaz1234
+/content/bn/ @Arindam200 @Imtiaz1234 @mitul3737 @sajibAdhi
+
+# Approvers for German contents
+/content/de/ @iamNoah1 @DaveVentura @CathPag @bcubk
 
 # Approvers for Spanish contents
 /content/es/ @raelga @ramrodo @electrocucaracha @krol3 @92nqb
 
-# Approvers for Simplified Chinese contents
-/content/zh-cn/ @hanyuancheung @Jacob953 @Rocksnake @Submarinee
-
 # Approvers for French contents
 /content/fr/ @huats @fydrah @Krast76 @sestegra
 
+# Approvers for Hindi contents
+/content/hi/ @Garima-Negi @sayantani11 @anubha-v-ardhan @jayesh-srivastava
+
+# Approvers for Italian contents
+/content/it/ @fsbaraglia @ugho16 @annalisag-spark @sistella
+
+# Approvers for Japanese contents
+/content/ja/ @inductor @naonishijima @kaitoii11
+
+# Approvers for Korean contents
+/content/ko/ @seokho-son @jihoon-seo @yunkon-kim
+
+# Approvers for Portuguese contents
+/content/pt-br/ @edsoncelio @brunoguidone @jessicalins @MrErlison
+
+# Approvers for Turkish contents
+/content/tr/ @aliok @halil-bugol @developer-guy @eminalemdar
+
 # Approvers for Urdu contents
 /content/ur/ @Saim-Safdar @waleed318
+
+# Approvers for Simplified Chinese contents
+/content/zh-cn/ @hanyuancheung @Jacob953 @Rocksnake @Submarinee
 
 # Approvers for Traditional Chinese contents
 /content/zh-tw/ @pichuang @ydFu


### PR DESCRIPTION
### Describe your changes

This PR updates CODEOWNERS file to be aligned with the changes in the PR #2046.
- Add Japanese approvers for the path `content/ja/`
- Add Turkish approvers for the path `content/tr/` to be created
- Remove `@Eviekim` from the list of Korean approvers


After this PR gets merged into `main`, if someone merges `main` into `dev-ja`,
then the GitHub automatic review request to Japanese approvers will work for the path `content/ja/`.
(Currently it is not working; e.g., please see #2127.)

### Related issue number or link (ex: `resolves #issue-number`)

None

### Checklist before opening this PR (put `x` in the checkboxes)
- [X] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [X] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
