### PR TITLE
Added a procedure to join the CNCF Slack workspace on main page

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -20,7 +20,7 @@ This Glossary provides a vendor-neutral platform to organize a shared vocabulary
 Contributions are welcome from all participants who abide by the project's purpose and charter.
 
 Anyone who wishes to make a contribution may submit a GitHub issue or create a pull request. 
-Please ensure you follow the [Style Guide](/style-guide/), read the [How To Contribute](/contribute/) doc, and join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel on the CNCF Slack.
+Please ensure you follow the [Style Guide](/style-guide/), read the [How To Contribute](/contribute/) doc, and join the [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) workspace, and join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel.
 There is also a [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) channel for those who want to help translate the glossary into their native language.
 
 ## Acknowledgements

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -20,7 +20,7 @@ This Glossary provides a vendor-neutral platform to organize a shared vocabulary
 Contributions are welcome from all participants who abide by the project's purpose and charter.
 
 Anyone wishing to contribute may submit a GitHub issue or create a pull request.
-Please ensure you follow the [Style Guide](/style-guide/), read the [How To Contribute](/contribute/) doc, and join the [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) workspace, and join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel.
+Please ensure you follow the [Style Guide](/style-guide/), read the [How To Contribute](/contribute/) doc, join the [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) workspace, and join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel.
 There is also a [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) channel for those who want to help translate the glossary into their native language.
 
 ## Acknowledgements

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -19,7 +19,7 @@ We employ a community-driven process governed by the CNCF to develop and improve
 This Glossary provides a vendor-neutral platform to organize a shared vocabulary around cloud native technologies. 
 Contributions are welcome from all participants who abide by the project's purpose and charter.
 
-Anyone who wishes to make a contribution may submit a GitHub issue or create a pull request. 
+Anyone wishing to contribute may submit a GitHub issue or create a pull request.
 Please ensure you follow the [Style Guide](/style-guide/), read the [How To Contribute](/contribute/) doc, and join the [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) workspace, and join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel.
 There is also a [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) channel for those who want to help translate the glossary into their native language.
 


### PR DESCRIPTION
### Describe your changes

I've seen contributors struggle with joining the glossary's Slack channel via link.

(for example) #glossary-localization-korean: https://cloud-native.slack.com/archives/C02PC0MLQKU
In that case, we had to manually add them using the Slack channel's "Add People" feature.

So what I did is, a solution for contributors to join the CNCF Slack workspace first on the link, https://communityinviter.com/apps/cloud-native/cncf.

<img width="827" alt="Screenshot 2023-06-14 at 5 44 01 PM" src="https://github.com/cncf/glossary/assets/91361382/a3ef056f-9032-485d-8a02-b4363f52a326">


This could be a way for contributors to join Glossary using only a guide.

### Related issue number or link 

Resolves #2082 

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
