### PR TITLE
Add `castrojo` to the list of English approvers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -44,6 +44,9 @@ collaborators:
   - username: nate-double-u
     permission: admin
 
+  - username: castrojo
+    permission: push
+
   # Localization approvers
   
   # l10n ko approvers
@@ -226,6 +229,7 @@ branches:
          - iamNoah1
          - jihoon-seo
          - nate-double-u
+         - castrojo
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 
 
 # Approvers for English content
-/content/en/ @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u
+/content/en/ @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @castrojo
 
 
 # These are the owners (approvers) for localization contents


### PR DESCRIPTION
### Describe your changes
This PR update .github/settings.yml and CODEOWNERS to invite @castrojo as an approver for English content in this Repo.
Based on maintainers' decision. :)

### Related issue number or link (ex: `resolves #issue-number`)
None

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
