### PR TITLE
Enable check outdated gh action in dev-es

### DIFF
--- a/.github/workflows/check-outdated-content.yaml
+++ b/.github/workflows/check-outdated-content.yaml
@@ -39,31 +39,26 @@ jobs:
         # Set output direcory
         OUTPUT_DIR="./outdated"
         
-        # Set L10n directory and code
+        # Set L10n code
+        L10N_CODE="${L10N_BRANCH//dev-/}"
+        echo "(DEBUG) L10N Code: ${L10N_CODE}"
+
+        # Set L10n directory
         case "${L10N_BRANCH}" in
           dev-pt)
-          L10N_DIR="content/pt-br/"
-          L10N_CODE="pt-br"
+          L10N_DIR="./content/pt-br/"
           ;;
-
           dev-zh)
-          L10N_DIR="content/zh-cn/"
-          L10N_CODE="zh-cn"
+          L10N_DIR="./content/zh-cn/"
           ;;
-
           dev-tw)
-          L10N_DIR="content/zh-tw/"
-          L10N_CODE="zh-tw"
+          L10N_DIR="./content/zh-tw/"
           ;;
-
           *)
-          L10N_CODE="${L10N_BRANCH//dev-/}"
           L10N_DIR="./content/${L10N_CODE}/"
           ;;
         esac
-        
         echo "(DEBUG) L10N Directory: ${L10N_DIR}"
-        echo "(DEBUG) L10N Code: ${L10N_CODE}"
         
         # Set L10N_DIR, L10N_CODE, and OUTPUT_DIR as environment variables
         # Ref: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
@@ -106,7 +101,6 @@ jobs:
         # The old branch can be 'upstream/dev-ko'
         OLD_BRANCH="origin/${{github.base_ref}}"
         echo "(DEBUG) OLD_BRANCH: ${OLD_BRANCH}"
-        echo "(DUBUG) OLD_BRANCH: ${OLD_BRANCH}"
 
         L10N_INFO_JSON=$(cat <<EOF
         {

--- a/.github/workflows/check-outdated-content.yaml
+++ b/.github/workflows/check-outdated-content.yaml
@@ -43,12 +43,17 @@ jobs:
         case "${L10N_BRANCH}" in
           dev-pt)
           L10N_DIR="content/pt-br/"
-          L10N_CODE="pt"
+          L10N_CODE="pt-br"
           ;;
 
           dev-zh)
           L10N_DIR="content/zh-cn/"
-          L10N_CODE="zh"
+          L10N_CODE="zh-cn"
+          ;;
+
+          dev-tw)
+          L10N_DIR="content/zh-tw/"
+          L10N_CODE="zh-tw"
           ;;
 
           *)

--- a/.github/workflows/check-outdated-content.yaml
+++ b/.github/workflows/check-outdated-content.yaml
@@ -4,7 +4,8 @@ name: Check outdated content
 on: 
   pull_request:
     branches:
-      - 'dev-ko' # add other branches or use wildcard 'dev-**'
+      - 'dev-ko'
+      - 'dev-es'
     paths:
       - 'content/en/**.md'
 
@@ -12,10 +13,10 @@ jobs:
   check-outdated-content:
     name: Check outdated content
 
-    # if: contains(fromJSON('["dev-ko", "dev-xx"]'), github.base_ref) 
+    if: contains(fromJSON('["dev-ko","dev-es"]'), github.base_ref)
     # Ref: https://docs.github.com/en/actions/learn-github-actions/expressions
 
-    if: github.base_ref == 'dev-ko'
+    #if: github.base_ref == 'dev-ko'
     
     # Condition to run this workflow on the upstream repository
     #if: github.repository == 'cncf/glossary'
@@ -40,15 +41,20 @@ jobs:
         
         # Set L10n directory and code
         case "${L10N_BRANCH}" in
-          dev-ko)          
-          L10N_DIR="content/ko/"
-          L10N_CODE="ko"
+          dev-pt)
+          L10N_DIR="content/pt-br/"
+          L10N_CODE="pt"
           ;;
-          
-          #dev-pt)
-          #L10N_DIR="content/pt-br/"
-          #L10N_CODE="pt"
-          #;;
+
+          dev-zh)
+          L10N_DIR="content/zh-cn/"
+          L10N_CODE="zh"
+          ;;
+
+          *)
+          L10N_CODE="${L10N_BRANCH//dev-/}"
+          L10N_DIR="./content/${L10N_CODE}/"
+          ;;
         esac
         
         echo "(DEBUG) L10N Directory: ${L10N_DIR}"
@@ -89,11 +95,12 @@ jobs:
         # Get the lastest branch name from 'GITHUB_REF' 
         # The latest branch can be 'upstream/main' or 'forked/dev-ko' (rebased)
         LATEST_BRANCH=${GITHUB_REF#refs/}
-        echo "(DUBUG) LATEST_BRANCH: ${LATEST_BRANCH}"
+        echo "(DEBUG) LATEST_BRANCH: ${LATEST_BRANCH}"
         
         # Get the old branch from 'github.base_ref' 
         # The old branch can be 'upstream/dev-ko'
         OLD_BRANCH="origin/${{github.base_ref}}"
+        echo "(DEBUG) OLD_BRANCH: ${OLD_BRANCH}"
         echo "(DUBUG) OLD_BRANCH: ${OLD_BRANCH}"
 
         L10N_INFO_JSON=$(cat <<EOF
@@ -144,7 +151,7 @@ jobs:
               fi
 
             else
-              echo "(DEBUG) ${FILE_PATH} dose not exist."
+              echo "(DEBUG) ${FILE_PATH} does not exist."
               # File dose not exist (e.g, changed, renamed or removed)
               echo "Could not find ${FILE_PATH} in content/en/" > ${OUTPUT_DIR}/${FILE_PATH}
               echo "Need to check if it has been changed, renamed or removed" >> ${OUTPUT_DIR}/${FILE_PATH}


### PR DESCRIPTION
### Describe your changes
This change fixes some types and enables the Check outdated terms in the `dev-es` branch

### Related issue number or link (ex: `resolves #issue-number`)
NA

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
