### PR TITLE
Add missing sestegra for merging into dev-fr

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -418,6 +418,7 @@ branches:
          - huats
          - fydrah
          - Krast76
+         - sestegra
         teams: []
       enforce_admins: null
       required_linear_history: null


### PR DESCRIPTION
### Describe your changes

`sestegra` is missing for merging into dev-fr branch

### Related issue number or link (ex: `resolves #issue-number`)

N/A

### Checklist before opening this PR (put `x` in the checkboxes)
- [X] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [X] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
