### PR TITLE
chore: Fix whitespace and a few trivial typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,6 @@ Below are the guidelines for how to contribute to the code that runs the CNCF Gl
 ## How can I contribute?
 
 1. **Report a bug**. If you see a technical issue with the CNCF Glossary site or something that doesn't look right, search [the existing issues](https://github.com/cncf/glossary/issues) to see if it has been reported already. If not, please [create a new issue](https://github.com/cncf/glossary/issues/new) describing the bug. Please provide all steps necessary to reproduce the bug and screenshots if applicable.
-2. **Fix a bug**. Find [an issue](https://github.com/cncf/glossary/issues) you want to fix and submit a PR for approval. 
+2. **Fix a bug**. Find [an issue](https://github.com/cncf/glossary/issues) you want to fix and submit a PR for approval.
 
 Read [more about the code that runs the Glossary site](https://github.com/cncf/glossary/blob/main/spin-new-glossary.md) and [how to set up your own local development instance](https://github.com/cncf/glossary#setting-up-a-local-instance). To connect with our community and ask questions, please join [the #glossary channel on the CNCF slack](https://cloud-native.slack.com/archives/C02TX20MQBB).

--- a/LOCALIZATION.md
+++ b/LOCALIZATION.md
@@ -138,6 +138,7 @@ If the team seems inactive (no response after several days), reach out to @Seokh
 --- 
 
 # Localization team guidelines
+
 Every localization team may have its own process of working on localizing terms. However, here are some guidelines that are common for all localization teams:
 
 1. Only terms with the status `Completed` in the English version are ready to be localized.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Committee (Business Value Subcommittee) and includes contributions
 from [Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), [Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/),
 [Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk), [Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), [Katelin Ramer](https://www.linkedin.com/in/katelinramer/) and [Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca).
 
-## License 
+## License
 
 All code contributions are under the Apache 2.0 license. Documentation is distributed under CC BY 4.0.
 

--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,7 +1,7 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
 {{/* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */}}
-{{/* Indvidual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */}}
+{{/* Individual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */}}
 {{- $.Scratch.Add "offline-search-index" (dict "ref" .RelPermalink "title" .Title "status" (.Params.status | default "") "body" (.Plain | htmlUnescape) "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)) -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/content/en/container-orchestration.md
+++ b/content/en/container-orchestration.md
@@ -5,16 +5,19 @@ category: Concept
 ---
 
 ## What it is
+
 [Container](/container/) orchestration refers to managing and automating the lifecycle of containerized applications in dynamic environments. 
 It's executed through a container orchestrator (in most cases, [Kubernetes](/kubernetes)), which enables deployments, (auto)scaling, auto-healing, and monitoring. 
 Orchestration is a metaphor:
 The orchestration tool conducts containers like a music conductor, ensuring every container (or musician) does what it should. 
 
 ## Problem it addresses 
+
 Managing [microservices](/microservices), security, and network communication at scale — and [distributed systems](/distributed-systems) in general — is hard, if not impossible, to manage manually.
 Container orchestration allows users to automate all these management tasks. 
 
 ## How it helps
+
 Container orchestration tools allow users to determine a system's state. 
 First, they declare how it should look like (e.g., x containers, y pods, etc.).
 The orchestration tool will then automatically monitor the infrastructure and correct it if its state deviates from the declared one (e.g., spin up a new container if one crashes). 

--- a/content/en/edge-computing.md
+++ b/content/en/edge-computing.md
@@ -27,5 +27,3 @@ As described above, for edge devices to be useful, they must do at least part of
 This is achieved by shifting some storage and processing resources from the data center to where the data is generated: the edge device.
 Processed and unprocessed data is subsequently sent to the data center for further processing and storage.
 In short, efficiency and speed are the primary drivers of edge computing. 
-
-

--- a/spin-new-glossary.md
+++ b/spin-new-glossary.md
@@ -31,7 +31,7 @@ Complete your local dev setup using [these instructions](https://github.com/cncf
 
 Edit `config.toml` to set title, Google Analytics, languages, copyright, social image, social links, and various other settings.
 
-Replace favicons in in the `static/favicons` directory with your own.
+Replace favicons in the `static/favicons` directory with your own.
 
 Replace `assets/icons/logo.svg` with your own logo.
 
@@ -42,7 +42,6 @@ Edit various static copy in the `layouts` folder as needed.
 ## Content
 
 Replace all content in the `content/en` folder with your own glossary terms. Create a language folder for each of the translation languages you will support. Note that terms will only be listed on the site when `status: Completed` in the header of the term file.
-
 
 ## Feedback buttons configuration
 


### PR DESCRIPTION
### Describe your changes

This PR fixes some minor whitespace issues (e.g., spacing around a Markdown heading, a few trailing quotes in non-primary content), as well as fixes one typo in repo guidance and one in a trivial comment.

From a consistency perspective, almost all of the primary content in `content/en/` uses spacing around Markdown headers (and most Markdown linters recommend that), so I just found a few which were lacking it so made them consistent.

Just minor editorial tweaks!

As always, love referring to this content; thanks for contributing it!

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
