### PR TITLE
Update path pattern in `.github/labeler.yml`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,40 +1,40 @@
 lang/ar:
-- content/ar/*
+- content/ar/**
 
 lang/bn:
-- content/bn/*
+- content/bn/**
 
 lang/de:
-- content/de/*
+- content/de/**
 
 lang/en:
-- content/en/*
+- content/en/**
 
 lang/es:
-- content/es/*
+- content/es/**
 
 lang/fr:
-- content/fr/*
+- content/fr/**
 
 lang/hi:
-- content/hi/*
+- content/hi/**
 
 lang/it:
-- content/it/*
+- content/it/**
 
 lang/ja:
-- content/ja/*
+- content/ja/**
 
 lang/ko:
-- content/ko/*
+- content/ko/**
 
 lang/pt:
-- content/pt-br/*
+- content/pt-br/**
 
 lang/tw:
-- content/zh-tw/*
+- content/zh-tw/**
 
 lang/zh:
-- content/zh-cn/*
+- content/zh-cn/**
 
 


### PR DESCRIPTION
### Describe your changes
- This PR will update path pattern in `.github/labeler.yml`.
- For example, `content/ko/*` changes to `content/ko/**`.
- This is required to include subdirectories in the labeling target.

See this [basic example from actions/labeler](https://github.com/actions/labeler#basic-examples)
> ```
> # Add 'label1' to any changes within 'example' folder or any subfolders
> label1:
> - example/**
> 
> # Add 'label2' to any file changes within 'example2' folder
> label2: example2/*
> 
> # Add label3 to any change to .txt files within the entire repository. Quotation marks are required for the leading asterisk
> label3:
>- '**/*.txt'
>```

### Related issue number or link (ex: `resolves #issue-number`)
- Ref. #2278 
- When I created a PR for updating `content/ko/contribute/_index.md`, the github-actions `bot` removed the label from the PR.

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
