### PR TITLE
Update ownership and emeritus state

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -83,7 +83,6 @@ collaborators:
     permission: push
 
   # l10n de approvers
-  # Note: CathPag is both Maintainer (maintain) and de approver (push)
   # Note: iamNoah1 is both Maintainer (maintain) and de approver (push)
   - username: DaveVentura
     permission: push
@@ -180,6 +179,12 @@ collaborators:
     permission: push
 
   # l10n zh-tw approvers
+  - username: hwchiu
+    permission: push
+
+  - username: johnlinp
+    permission: push
+
   - username: pichuang
     permission: push
 
@@ -196,6 +201,9 @@ collaborators:
   - username: naonishijima
     permission: push
 
+  - username: yuichi-nakamura
+    permission: push
+
   # l10n tr approvers
   - username: aliok
     permission: push
@@ -207,6 +215,13 @@ collaborators:
     permission: push
 
   - username: eminalemdar
+    permission: push
+
+  # l10n ru approvers
+  - username: shurup
+    permission: push
+
+  - username: kirkonru
     permission: push
 
 branches:
@@ -451,6 +466,8 @@ branches:
         apps: []
         # zh-tw approvers
         users:
+         - hwchiu
+         - johnlinp
          - pichuang
          - ydFu
         teams: []
@@ -471,6 +488,7 @@ branches:
          - inductor
          - kaitoii11
          - naonishijima
+         - yuichi-nakamura
         teams: []
       enforce_admins: null
       required_linear_history: null
@@ -490,6 +508,23 @@ branches:
          - halil-bugol
          - developer-guy
          - eminalemdar
+        teams: []
+      enforce_admins: null
+      required_linear_history: null
+
+  # l10n branch for ru contents only
+  - name: dev-ru
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: true
+      required_status_checks: null
+      restrictions:
+        apps: []
+        # ru approvers
+        users:
+         - shurup
+         - kirkonru
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,13 +5,13 @@
 # when someone opens a pull request that modifies code that they own.
 
 # These owners will be default owners for everything in this repository.
-# These owners consist of Maintainers and English approvers.
-* @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u
+# These owners consist of Maintainers
+* @caniszczyk @seokho-son @iamNoah1 @jihoon-seo @nate-double-u
 
 
 # Approvers for English content
-/content/en/ @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @castrojo
-/i18n/en.toml @caniszczyk @CathPag @jasonmorgan @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @castrojo
+/content/en/ @caniszczyk @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @castrojo
+/i18n/en.toml @caniszczyk @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @castrojo
 
 
 # These are the owners (approvers) for localization contents
@@ -47,8 +47,8 @@
 /i18n/it.toml @fsbaraglia @ugho16 @annalisag-spark @sistella
 
 # Approvers for Japanese contents
-/content/ja/ @inductor @naonishijima @kaitoii11
-/i18n/ja.toml @inductor @naonishijima @kaitoii11
+/content/ja/ @inductor @naonishijima @kaitoii11 @yuichi-nakamura
+/i18n/ja.toml @inductor @naonishijima @kaitoii11 @yuichi-nakamura
 
 # Approvers for Korean contents
 /content/ko/ @seokho-son @jihoon-seo @yunkon-kim
@@ -57,6 +57,10 @@
 # Approvers for Portuguese contents
 /content/pt-br/ @edsoncelio @brunoguidone @jessicalins @MrErlison
 /i18n/pt-br.toml @edsoncelio @brunoguidone @jessicalins @MrErlison
+
+# Approvers for Russian contents
+/content/ru/ @shurup @kirkonru
+/i18n/ru.toml @shurup @kirkonru
 
 # Approvers for Turkish contents
 /content/tr/ @aliok @halil-bugol @developer-guy @eminalemdar
@@ -71,5 +75,5 @@
 /i18n/zh-cn.toml @hanyuancheung @Jacob953 @Rocksnake @Submarinee
 
 # Approvers for Traditional Chinese contents
-/content/zh-tw/ @pichuang @ydFu
-/i18n/zh-tw.toml @pichuang @ydFu
+/content/zh-tw/ @pichuang @ydFu @hwchiu @johnlinp
+/i18n/zh-tw.toml @pichuang @ydFu @hwchiu @johnlinp

--- a/LOCALIZATION.md
+++ b/LOCALIZATION.md
@@ -133,7 +133,7 @@ Once the PR is merged, the localized content will go live on its website 🎉
 
 To join an existing team, hop on the #glossary-localizations and #glossary-localization-[language name] channels on the CNCF Slack. Introduce yourself, let the team know you want to contribute, and the team will take it from there.
 
-If the team seems inactive (no response after several days), reach out to @Seokho Son, @Catherine Paganini, @jmo, @Jihoon Seo or @Noah Ispas on the #glossary-localizations channel.  
+If the team seems inactive (no response after several days), reach out to @Seokho Son, @Jihoon Seo, @nate-double-u, or @Noah Ispas on the #glossary-localizations channel.  
 
 --- 
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,28 @@ If you'd like to help with the glossary we'd love to have your contributions! Pl
 
 ## Acknowledgements
 
-The Cloud Native Glossary was initiated by the CNCF Marketing 
-Committee (Business Value Subcommittee) and includes contributions 
-from [Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), [Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/),
-[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk), [Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), [Katelin Ramer](https://www.linkedin.com/in/katelinramer/) and [Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca).
+The Cloud Native Glossary was initiated by the CNCF Marketing Committee
+(Business Value Subcommittee) and includes contributions from 
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), 
+[Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/), 
+[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk), 
+[Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), 
+[Katelin Ramer](https://www.linkedin.com/in/katelinramer/), 
+[Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca), 
+and many more contributors. 
+For a complete contributor list, please refer to [this GitHub page](https://github.com/cncf/glossary/graphs/contributors).
+
+The Glossary is maintained by 
+[Seokho Son](https://www.linkedin.com/in/seokho-son/),
+[Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/), 
+[Jihoon Seo](https://www.linkedin.com/in/jihoon-seo/),
+[Nate W.](https://www.linkedin.com/in/nate-double-u/),
+and [Jorge Castro](https://www.linkedin.com/in/jorge-castro2112/).
+
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/),
+and [Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/)
+are Emeritus Maintainers, and we are deeply grateful
+for their invaluable contributions over the years.
 
 ## License
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -36,11 +36,16 @@ and many more contributors.
 For a complete contributor list, please refer to [this GitHub page](https://github.com/cncf/glossary/graphs/contributors).
 
 The Glossary is maintained by 
-[Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/), 
 [Seokho Son](https://www.linkedin.com/in/seokho-son/),
-[Jihoon Seo](https://www.linkedin.com/in/jihoon-seo/), 
-[Jorge Castro](https://www.linkedin.com/in/jorge-castro2112/),
-and [Nate W.](https://www.linkedin.com/in/nate-double-u/).
+[Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/), 
+[Jihoon Seo](https://www.linkedin.com/in/jihoon-seo/),
+[Nate W.](https://www.linkedin.com/in/nate-double-u/),
+and [Jorge Castro](https://www.linkedin.com/in/jorge-castro2112/).
+
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/),
+and [Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/)
+are Emeritus Maintainers, and we are deeply grateful
+for their invaluable contributions over the years.
 
 ## License
 

--- a/content/en/contribute/_index.md
+++ b/content/en/contribute/_index.md
@@ -84,7 +84,7 @@ Once you select a term to work on, comment on the issue.
 ![Claiming an issue](/images/how-to/claiming-an-issue.png)
 
 Additionally, notify the maintainers on the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel of the CNCF Slack workspace and 
-tag  _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_, and/or _@castrojo_ to be sure they don't miss it. 
+tag _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_, and/or _@castrojo_ to be sure they don't miss it.
 
 For the next steps, please refer to the [Submitting a new term (creating a PR)](#submitting-a-new-term) section.
 
@@ -125,7 +125,7 @@ Next, the maintainers will triage the issue.
 That means they will assess if the term should be part of the Glossary. 
 Not every term will be admitted. To be included in the Glossary, they should be established and widely-used cloud native concepts.
 
-Please let the maintainers know that you've proposed a new term on Slack and tag _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_, and/or _@castrojo_ so that they don't miss it.  
+Please let the maintainers know that you've proposed a new term on Slack and tag _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_, and/or _@castrojo_ so that they don't miss it.
 If you want to work on the definition, let the maintainers know and they'll assign it to you.
 
 ### Submitting a new term (creating a PR) {#submitting-a-new-term}


### PR DESCRIPTION
### Describe your changes
This PR updates overall ownership and emeritus state. (collected all recent requests)

#### Maintainers
Based on #2268 and Slack & Monthly meeting consensus. 
- Move @CathPag and @JasonMorgan to emeritus maintainer.
- Remove @CathPag and @JasonMorgan from the codeowner so that they are not notified for review. (but, they have still authority to merge PRs)

> Seokho Son
> A simple thank you doesn't seem fitting for [@Catherine](https://cloud-native.slack.com/team/U5U4E68P4). In fact, she's the main maintainer who led and sphread the Glossary project, and friend who "dragged" me in here. On behalf of all Glossary contributors and Cloud Native users, I want to say a huge, huge thank you! 
> Also, I would like to keep Catherine as an emeritus maintainer, someone we can occasionally turn to for advice as she passes by. (also to welcome whenever she is available to come back)


#### Localization approvers
- Add approvers for Russian Team based on #2220 
  - [x] @shurup 
  - [x] @kirkonru 
- Add approvers for Traditional Chinese Team based on #2321
  - [x] @hwchiu 
  - [x] @johnlinp 
- Add approver for Japanese Team based on https://github.com/cncf/glossary/issues/1422#issuecomment-1654752535
  - [x] @yuichi-nakamura 

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
