### PR TITLE
devRel : Added new term in glossary

### DIFF
--- a/content/en/devRel.md
+++ b/content/en/devRel.md
@@ -1,0 +1,23 @@
+"DevRel" stands for Developer Relations, which is a role or function within a company or organization that focuses on building and nurturing relationships between developers and the company's products, services, or developer ecosystem. DevRel teams aim to create a positive and productive interaction between developers and the company, often in the context of technology platforms, APIs, software development tools, and developer communities.
+
+Here are some key aspects of Developer Relations:
+
+1. **Advocacy:** DevRel professionals often act as advocates for developers, representing their interests within the company. They advocate for developer-friendly practices, documentation, and product improvements.
+
+2. **Education and Support:** They provide educational resources, such as tutorials, guides, webinars, and workshops, to help developers better understand and use the company's products and services.
+
+3. **Feedback Loop:** DevRel teams collect feedback from developers, relay it to the relevant teams within the company, and ensure that developers' concerns and needs are addressed.
+
+4. **Community Building:** They foster and nurture developer communities around the company's products, helping developers connect, collaborate, and share their experiences.
+
+5. **Content Creation:** DevRel professionals often create content like blog posts, videos, and sample code to showcase the capabilities of the company's products and demonstrate best practices.
+
+6. **Evangelism:** They promote the company's technologies and tools at developer conferences, meetups, and online forums. They often serve as speakers, panelists, or presenters.
+
+7. **Relationship Building:** Building and maintaining relationships with key influencers, open-source projects, and other organizations in the developer ecosystem is a significant part of the role.
+
+8. **Documentation:** Ensuring that documentation is accurate, comprehensive, and user-friendly is crucial for DevRel teams. They may directly contribute to or work closely with technical writers to improve documentation.
+
+9. **Feedback Channels:** Establishing various feedback channels, such as forums, discussion boards, or chat groups, where developers can interact with both DevRel professionals and each other.
+
+DevRel is common in technology companies, especially those offering developer-focused products like APIs, SDKs, cloud services, or software development tools. It plays a vital role in ensuring that developers have a positive experience with a company's offerings and that the company benefits from developer adoption and engagement.


### PR DESCRIPTION
### Describe your changes
###I actually create issue there is no term about devRel
##Why this term needs to be added? 
1. there should be page about DevRel engineer what they actually do.
2. they are developer, or community builder much to be know about this.
3. I want this this term to be added like Devops in side drawer we can search with tag.
 learn new about this role in community.


### Related issue number or link (ex: `resolves #2427 `)


### Checklist before opening this PR (put `x` in the checkboxes)
- [X] This PR does not contain plagiarism
- But I take help from chatGPT so my english not so good
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [X] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
