### PR TITLE
[tw] Unify the translation for the term `property`

### DIFF
--- a/content/zh-tw/abstraction.md
+++ b/content/zh-tw/abstraction.md
@@ -1,7 +1,7 @@
 ---
 title: 抽象
 status: Completed
-category: 特性
+category: 屬性
 tags: ["基本原理", "", ""]
 ---
 


### PR DESCRIPTION
### Describe your changes
We currently have different translations for the term property -- `特性` and `屬性`. Based on the discussion in https://github.com/cncf/glossary/pull/2496#discussion_r1359176797, we'd like to unify the translation as the latter.

### Related issue number or link (ex: `resolves #issue-number`)

resolves #2505

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
