### PR TITLE
Updating Twitter logo to X

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,13 +14,9 @@
 				<a href="https://www.cncf.io/all-cncf/" class="hub-button">{{ T "footer_hub_button_text" }}</a>
 			</div>
 			<ul class="social-links">
-				<li><a class="text-white" title="Cloud Native Computing Foundation on Twitter"
-						href="https://twitter.com/cloudnativefdn"><svg xmlns="http://www.w3.org/2000/svg"
-							viewbox="-0.61 -0.55 31.72 25.84">
-							<path fill="currentColor"
-								d="M30.579 3.018c-1.145.503-2.36.833-3.603.98A6.252 6.252 0 0 0 29.734.556a12.628 12.628 0 0 1-3.982 1.51A6.297 6.297 0 0 0 22.193.187a6.327 6.327 0 0 0-3.977.655A6.249 6.249 0 0 0 15.46 3.76a6.178 6.178 0 0 0-.398 3.978 17.93 17.93 0 0 1-7.165-1.887 17.784 17.784 0 0 1-5.769-4.614 6.182 6.182 0 0 0-.687 4.533A6.228 6.228 0 0 0 4.07 9.54a6.288 6.288 0 0 1-2.842-.777v.078c0 1.436.502 2.829 1.419 3.94a6.286 6.286 0 0 0 3.614 2.16 6.34 6.34 0 0 1-2.833.107A6.23 6.23 0 0 0 5.66 18.14a6.315 6.315 0 0 0 3.628 1.229 12.657 12.657 0 0 1-7.791 2.663c-.5 0-1-.03-1.497-.087a17.868 17.868 0 0 0 9.617 2.794c11.54 0 17.849-9.479 17.849-17.697 0-.27-.006-.538-.018-.805a12.692 12.692 0 0 0 3.13-3.22z" />
-						</svg> </a></li>
-
+				<li><a class="text-white" title="Cloud Native Computing Foundation on X"
+						href="https://x.com/cloudnativefdn"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" aria-label="X"><path fill="currentColor" d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"/></svg>
+					</a></li>
 				<li><a class="text-white" title="Cloud Native Computing Foundation on Github"
 						href="https://github.com/cncf"><svg xmlns="http://www.w3.org/2000/svg"
 							viewbox="-0.1 0.21 24.7 24.14">


### PR DESCRIPTION
### Describe your changes

Updating the Twitter logo in the footer to X (as well as the URL to the CNCF Twitter page)

![Screenshot-2023-10-29 --22 52 12@2x](https://github.com/cncf/glossary/assets/10615884/a623324d-addd-4f19-80f6-6422d6fcac17)

### Related issue number or link (ex: `resolves #issue-number`)

Part of updating all CNCF sub-sites - https://github.com/cncf/cncf.io/issues/769

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
