### PR TITLE
Add additional approver for Russian

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -227,6 +227,9 @@ collaborators:
   - username: kirkonru
     permission: push
 
+  - username: tym83
+    permission: push
+
 branches:
 
   # Default branch of this repository for configurations and English contents
@@ -529,6 +532,7 @@ branches:
         users:
          - shurup
          - kirkonru
+         - tym83
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,8 +59,8 @@
 /i18n/pt-br.toml @edsoncelio @brunoguidone @jessicalins @MrErlison
 
 # Approvers for Russian contents
-/content/ru/ @shurup @kirkonru
-/i18n/ru.toml @shurup @kirkonru
+/content/ru/ @shurup @kirkonru @tym83
+/i18n/ru.toml @shurup @kirkonru @tym83
 
 # Approvers for Turkish contents
 /content/tr/ @aliok @halil-bugol @developer-guy @eminalemdar


### PR DESCRIPTION
### Describe your changes
Add a new approver for Russian based on a requested by the localization team.
- [A] Timur Tukaev (@tym83)

### Related issue number or link (ex: `resolves #issue-number`)
- Requested by the Russian localization team: https://cloud-native.slack.com/archives/C05G46RMQTX/p1698057198264159?thread_ts=1698038167.603209&cid=C05G46RMQTX

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
