### PR TITLE
Replace developer-guy with rwxdash as TR approver

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -220,7 +220,7 @@ collaborators:
   - username: halil-bugol
     permission: push
 
-  - username: developer-guy
+  - username: rwxdash
     permission: push
 
   - username: eminalemdar
@@ -521,7 +521,7 @@ branches:
         users:
          - aliok
          - halil-bugol
-         - developer-guy
+         - rwxdash
          - eminalemdar
         teams: []
       enforce_admins: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,8 +63,8 @@
 /i18n/ru.toml @shurup @kirkonru @tym83
 
 # Approvers for Turkish contents
-/content/tr/ @aliok @halil-bugol @developer-guy @eminalemdar
-/i18n/tr.toml @aliok @halil-bugol @developer-guy @eminalemdar
+/content/tr/ @aliok @halil-bugol @rwxdash @eminalemdar
+/i18n/tr.toml @aliok @halil-bugol @rwxdash @eminalemdar
 
 # Approvers for Urdu contents
 /content/ur/ @Saim-Safdar @waleed318


### PR DESCRIPTION
### Describe your changes

I'm stepping down from my role in the Turkish glossary team since I was not an active member of the community so I believe @rwxdash will be more active than I'm. 

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
