### PR TITLE
Add keywords to wordlist.txt failing spellcheck

### DIFF
--- a/wordlist.txt
+++ b/wordlist.txt
@@ -92,6 +92,7 @@ gmail
 gmail's
 hackable
 handoffs
+HAProxy
 highlight
 html
 http
@@ -137,6 +138,7 @@ multitenant
 namespace
 namespaces
 navbar
+Nginx
 observability
 oci
 oliveira
@@ -199,6 +201,7 @@ tilde
 tls
 tmp
 toolchain
+Traefik
 transcodes
 txt
 ubuntu


### PR DESCRIPTION
### Describe your changes

Issue #2679 mentions some keywords that were added previously when spellcheck workflow was not active. Now the checks are failing.

Adding the keywords should fix the Github spellcheck workflow.


### Related issue number or link (ex: `resolves #issue-number`)
resolves #2679 


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
