### PR TITLE
Try to explicitly set HUGO_ENV in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
 [build.environment]
 NODE_VERSION = "18.16.1"
 HUGO_VERSION = "0.115.2"
+
+[context.production.environment]
+HUGO_ENV = "production"
+
+[context.deploy-preview.environment]
+HUGO_ENV = "preview"


### PR DESCRIPTION
To address [this issue](https://github.com/cncf/cncf.io/issues/824), we want to explicitly set `HUGO_ENV` so that it only is "production" on the production instance of the site. This is important so we don't run Google Analytics on preview or dev instances.