### PR TITLE
add info about not completed terms

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-term.yml
+++ b/.github/ISSUE_TEMPLATE/new-term.yml
@@ -34,7 +34,7 @@ body:
           required: true
         - label: The term has not already been declined in the past. [(shift+click to check)](https://github.com/cncf/glossary/issues?q=is%3Aissue+is%3Aclosed+label%3A%22triage%2Fnot+accepted%22)
           required: false
-        - label: The term does not already exist in the [glossary](https://glossary.cncf.io).
+        - label: The term does not already exist neither in the [glossary](https://glossary.cncf.io) as completed term, nor in [this directory](https://github.com/iamNoah1/glossary/tree/main/content/en) as not completed term. In case of the latter, you should create an issue to update the term.
           required: true
         - label: I understand that maintainers will assess if the term should be part of the Glossary. (Please be patient)
           required: true

--- a/.github/ISSUE_TEMPLATE/new-term.yml
+++ b/.github/ISSUE_TEMPLATE/new-term.yml
@@ -34,7 +34,7 @@ body:
           required: true
         - label: The term has not already been declined in the past. [(shift+click to check)](https://github.com/cncf/glossary/issues?q=is%3Aissue+is%3Aclosed+label%3A%22triage%2Fnot+accepted%22)
           required: false
-        - label: The term does not already exist neither in the [glossary](https://glossary.cncf.io) as completed term, nor in [this directory](https://github.com/iamNoah1/glossary/tree/main/content/en) as not completed term. In case of the latter, you should create an issue to update the term.
+        - label: The term does not already exist in the [glossary](https://glossary.cncf.io) as a completed term, nor does it exist in [this directory](https://github.com/cncf/glossary/tree/main/content/en) as an incomplete term. (If the status of the term is `Feedback Appreciated`, consider updating the term.)
           required: true
         - label: I understand that maintainers will assess if the term should be part of the Glossary. (Please be patient)
           required: true


### PR DESCRIPTION
### Describe your changes
When opening an issue, there was only a link to the glossary to check if suggested terms already exist. But we also have terms that are not finished, thus not show up in the glossary. Contributors who open an issue for a new term should also check there and create an issue to update the term instead of an issue to add the term. 

### Related issue number or link (ex: `resolves #issue-number`)
none

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
