### PR TITLE
Add additional approver for Japanese Localization team

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -506,6 +506,7 @@ branches:
          - inductor
          - kaitoii11
          - naonishijima
+         - Okabe-Junya
          - yuichi-nakamura
         teams: []
       enforce_admins: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -210,6 +210,9 @@ collaborators:
   - username: naonishijima
     permission: push
 
+  - username: Okabe-Junya
+    permission: push
+
   - username: yuichi-nakamura
     permission: push
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,8 +47,8 @@
 /i18n/it.toml @fsbaraglia @ugho16 @annalisag-spark @sistella
 
 # Approvers for Japanese contents
-/content/ja/ @inductor @naonishijima @kaitoii11 @yuichi-nakamura
-/i18n/ja.toml @inductor @naonishijima @kaitoii11 @yuichi-nakamura
+/content/ja/ @inductor @naonishijima @kaitoii11 @yuichi-nakamura @Okabe-Junya
+/i18n/ja.toml @inductor @naonishijima @kaitoii11 @yuichi-nakamura @Okabe-Junya
 
 # Approvers for Korean contents
 /content/ko/ @seokho-son @jihoon-seo @yunkon-kim


### PR DESCRIPTION
### Describe your changes

Add a new approver for Japanese Localization team

- [A] Junya Okabe (@Okabe-Junya)

### Related issue number or link (ex: `resolves #issue-number`)

Slack link: https://cloud-native.slack.com/archives/C057F81GFUG/p1705327504026509

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
