### PR TITLE
[ja] hotfix: fix typo in Initial localization contributors list

### DIFF
--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -40,7 +40,7 @@ status: Completed
 [Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/)、
 そして [Seokho Son](https://www.linkedin.com/in/seokho-son/)によってメンテナンスされています.
 
-クラウドネイティブ用語集の日本語化は、[Kaito Ii](https://github.com/kaitoii11)、[Kohei Ota](https://github.com/inductor)、[Yuishi Nakamura](https://github.com/yuichi-nakamura)、[MItabashi](https://github.com/bashi8128)、[HANABE926](https://github.com/HANABE926)、[Junya Okabe](https://github.com/Okabe-Junya)、[Akira Aiura](https://github.com/A-aiura)、[shizhenhu](https://github.com/shizhenhu)、[Nao Nishijima](https://github.com/naonishijima)の貢献を通じて開始されました。
+クラウドネイティブ用語集の日本語化は、[Kaito Ii](https://github.com/kaitoii11)、[Kohei Ota](https://github.com/inductor)、[Yuichi Nakamura](https://github.com/yuichi-nakamura)、[MItabashi](https://github.com/bashi8128)、[HANABE926](https://github.com/HANABE926)、[Junya Okabe](https://github.com/Okabe-Junya)、[Akira Aiura](https://github.com/A-aiura)、[shizhenhu](https://github.com/shizhenhu)、[Nao Nishijima](https://github.com/naonishijima)の貢献を通じて開始されました。
 クラウドネイティブ用語集の日本語への翻訳とローカライゼーションに興味のある方は、[#glossary-localization-japanese](https://app.slack.com/client/T08PSQ7BQ/C057F81GFUG) チャンネルにご参加ください。
 
 ## ライセンス


### PR DESCRIPTION
### Describe your changes

There was a typo in the contributor's name. The name `yuichi-nakamura` san was mistakenly written as `yuishi-nakamura`. This typo has been corrected.

<img width="1001" alt="Screenshot 2024-01-28 at 12 52 07" src="https://github.com/cncf/glossary/assets/86868255/14ee37c3-a7e0-4f25-bb7d-b93e7a7963e7">


### Related issue number or link (ex: `resolves #issue-number`)

no issue related to this PR

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
