### PR TITLE
[en] More interlinking for containerisation & virtualisation

### DIFF
--- a/content/en/container-orchestration.md
+++ b/content/en/container-orchestration.md
@@ -4,7 +4,7 @@ status: Completed
 category: Concept
 ---
 
-[Container](/container/) orchestration refers to managing and automating the lifecycle of containerized applications in dynamic environments. 
+[Container](/container/) orchestration refers to managing and automating the lifecycle of [containerized](/containerization/) applications in dynamic environments. 
 It's executed through a container orchestrator (in most cases, [Kubernetes](/kubernetes)), which enables deployments, (auto)scaling, auto-healing, and monitoring. 
 Orchestration is a metaphor:
 The orchestration tool conducts containers like a music conductor, ensuring every container (or musician) does what it should. 

--- a/content/en/containerization.md
+++ b/content/en/containerization.md
@@ -11,7 +11,7 @@ As long as the output is a container image that adheres to this standard, which 
 
 ## Problem it addresses 
 
-Before containers became prevalent, organizations relied on virtual machines (VMs) to 
+Before [containers](/container/) became prevalent, organizations relied on [virtual machines](/virtual-machine/) (VMs) to 
 orchestrate multiple applications on a single [bare-metal machine](/bare-metal-machine/). 
 VMs are significantly larger than containers and require a hypervisor to run. 
 Due to the storage, backup, and transfer of these larger VM templates, creating the VM templates is also slow. 

--- a/content/en/continuous-delivery.md
+++ b/content/en/continuous-delivery.md
@@ -10,8 +10,9 @@ in which code changes are automatically deployed into an acceptance environment
 (or, in the case of continuous deployment, into production). 
 CD crucially includes procedures to ensure that software is adequately tested 
 before deployment and provides a way to rollback changes if deemed necessary. 
-Continuous integration (CI) is the first step towards continuous delivery 
-(i.e., changes have to merge cleanly before being tested and deployed).
+[Continuous integration](/continuous-integration/) (CI) is the first step towards 
+continuous delivery (i.e., changes have to merge cleanly before being tested and 
+deployed).
 
 ## Problem it addresses
 
@@ -26,7 +27,7 @@ deploying more changes at once and increasing the risk that something goes wrong
 CD strategies create a fully automated path to production 
 that tests and deploys the software using various deployment strategies 
 such as [canary](/canary-deployment/) or [blue-green](/blue-green-deployment/) releases. 
-This allows developers to deploy code frequently,  giving them peace of mind that the new revision has been tested. 
+This allows developers to deploy code frequently, giving them peace of mind that the new revision has been tested. 
 
 ## Related terms
 

--- a/content/en/virtual-machine.md
+++ b/content/en/virtual-machine.md
@@ -31,4 +31,4 @@ VMs allow you to use your existing physical hardware resources better
 by placing multiple virtual machines on a single physical machine. 
 Not bound to a particular physical machine, VMs are also more resilient than physical machines. 
 When a physical machine needs to go offline, 
-the VMs running on it can be moved to another machine with little to no downtime
+the VMs running on it can be moved to another machine with little to no downtime.


### PR DESCRIPTION
### Describe your changes
Since the style guide encourages links to existing glossary terms, I think all these interlinks in containerisation, virtualisation, and CI/CD are helpful.

It also brings a bit more consistency. E.g., for now, the Continuous Deployment text links to Continuous Delivery and  Continuous Integration, but the Continuous Delivery text doesn't do it.

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
