### PR TITLE
[EN] update Function as a Service

### DIFF
--- a/content/en/function-as-a-service.md
+++ b/content/en/function-as-a-service.md
@@ -29,6 +29,6 @@ The cloud infrastructure necessary to run an app is active even when the app isn
 
 FaaS gives developers an [abstraction](/abstraction/) for running web applications in response to events without managing servers. 
 For example, uploading a file could trigger custom code that transcodes the file into various formats. 
-FaaS will auto-scale the infrastructure for heavy use, 
+FaaS will auto-scale the underlying infrastructure that runs the application code for heavy use, 
 and the developer does not have to spend any time or resources building the code for [scalability](/scalability/). 
 Billing is based on computation time alone, which means businesses do not have to pay when the functions are not in use.

--- a/content/en/function-as-a-service.md
+++ b/content/en/function-as-a-service.md
@@ -29,6 +29,6 @@ The cloud infrastructure necessary to run an app is active even when the app isn
 
 FaaS gives developers an [abstraction](/abstraction/) for running web applications in response to events without managing servers. 
 For example, uploading a file could trigger custom code that transcodes the file into various formats. 
-FaaS infrastructure will auto-scale the code for heavy use, 
+FaaS will auto-scale the infrastructure for heavy use, 
 and the developer does not have to spend any time or resources building the code for [scalability](/scalability/). 
 Billing is based on computation time alone, which means businesses do not have to pay when the functions are not in use.


### PR DESCRIPTION
### Describe your changes
Update `Function as a Service` term.

Line 32 says:
*FaaS infrastructure will auto-scale the code for heavy use*

It's not code that auto-scales, but the underlying infrastructure, the number of instances which are running the code.
I think this will be more accurate:
*FaaS will auto-scale the infrastructure for heavy use,*

### Related issue number or link (ex: `resolves #issue-number`)
The french localization team noticed this while translating the term: https://github.com/cncf/glossary/pull/2973
As this is a minor fix I didn't open an issue, I opened this PR directly.

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
