### PR TITLE
Update "Cloud Native Landscape's observability section" link

### DIFF
--- a/content/en/observability.md
+++ b/content/en/observability.md
@@ -9,7 +9,7 @@ Observability is a system property that defines the degree to which the system c
 It allows users to understand a system's state from these external outputs and take (corrective) action.
 
 Computer systems are measured by observing low-level signals such as CPU time, memory, disk space, and higher-level and business signals, including API response times, errors, transactions per second, etc.
-These observable systems are **observed** (or monitored) through specialized tools, so-called observability tools. A list of these tools can be viewed in the [Cloud Native Landscape's observability section](https://landscape.cncf.io/card-mode?category=observability-and-analysis&grouping=category).
+These observable systems are **observed** (or monitored) through specialized tools, so-called observability tools. A list of these tools can be viewed in the [Cloud Native Landscape's observability section](https://landscape.cncf.io/?group=projects-and-products&view-mode=card#observability-and-analysis--observability).
 
 Observable systems yield meaningful, actionable data to their operators, allowing them to achieve favorable outcomes (faster incident response, increased developer productivity) and less toil and downtime.
 


### PR DESCRIPTION
### Describe your changes

The current link to the CNCF Landscape observability section is not working anymore. This PR updates the link to a valid one.

- Current (not working):
https://landscape.cncf.io/card-mode?category=observability-and-analysis&grouping=category

![imagen](https://github.com/cncf/glossary/assets/2797052/4aa0f34d-b8b5-48e9-966d-579f7e27e566)

- Proposed:
https://landscape.cncf.io/?group=projects-and-products&view-mode=card#observability-and-analysis--observability

![imagen](https://github.com/cncf/glossary/assets/2797052/b342c11a-a8bf-46a5-b997-8f183009b0b1)


### Related issue number or link (ex: `resolves #issue-number`)

N/A

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
