### PR TITLE
Adding asem hamid as  CODEOWNERS for Bengali

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -125,6 +125,9 @@ collaborators:
   # l10n bn approvers
   - username: Arindam200
     permission: push
+    
+  - username: asem-hamid
+    permission: push
 
   - username: Imtiaz1234
     permission: push
@@ -390,6 +393,7 @@ branches:
         # bn approvers
         users:
          - Arindam200
+         - asem-hamid
          - Imtiaz1234
          - mitul3737
          - sajibAdhi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,8 +23,8 @@
 /i18n/ar.toml @TarekMSayed @same7ammar @AShabana @arezk84
 
 # Approvers for Bengali contents
-/content/bn/ @Arindam200 @Imtiaz1234 @mitul3737 @sajibAdhi
-/i18n/bn.toml @Arindam200 @Imtiaz1234 @mitul3737 @sajibAdhi
+/content/bn/ @Arindam200 @asem-hamid @Imtiaz1234 @mitul3737 @sajibAdhi
+/i18n/bn.toml @Arindam200 @asem-hamid @Imtiaz1234 @mitul3737 @sajibAdhi
 
 # Approvers for German contents
 /content/de/ @iamNoah1 @DaveVentura @CathPag @bcubk


### PR DESCRIPTION
### Describe your changes

This commit will add Asem Hamid as codeowners for the Bengali CNCF glossary.

### Related issue number or link (ex: `resolves #issue-number`)

Tracking Issue: https://github.com/cncf/glossary/issues/410

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
