### PR TITLE
[fr] Enable link checking, and normalize links, add missing

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -3,6 +3,6 @@ DirectoryPath: public
 # IgnoreDirectoryMissingTrailingSlash: true # FIXME
 IgnoreInternalEmptyHash: true # FIXME
 IgnoreDirs:
-  - ^(bn|de|es|fr|hi|it|ko|pt.*?|ru|tr|ur|zh.*?)/
+  - ^(bn|de|es|hi|it|ko|pt.*?|ru|tr|ur|zh.*?)/
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/pagefind

--- a/content/fr/container-orchestration.md
+++ b/content/fr/container-orchestration.md
@@ -4,14 +4,14 @@ status: Completed
 category: Concept
 ---
 
-L'orchestration de [Conteneurs](/fr/container/) fait référence à la gestion et à l'automatisation du cycle de vie d'applications conteneurisées au sein d'environnements dynamiques.
-Réalisée à l'aide d'un orchestrateur de conteneurs (la plupart du temps, [Kubernetes](/fr/kubernetes)), elle permet les déploiements, le passage à l'échelle (automatique), (l'auto-)remédiation et le monitoring.
+L'orchestration de [Conteneurs](/fr/container/) fait référence à la gestion et à l'automatisation du cycle de vie d'applications [conteneurisées](/containerization/) au sein d'environnements dynamiques.
+Réalisée à l'aide d'un orchestrateur de conteneurs (la plupart du temps, [Kubernetes](/fr/kubernetes/)), elle permet les déploiements, le passage à l'échelle (automatique), (l'auto-)remédiation et le monitoring.
 L'orchestration est une métaphore:
 L'outil d'orchestration dirige les conteneurs tel un chef d'orchestre, s'assurant que chaque conteneur (ou musicien) fait ce qu'il doit faire.
 
 ## Problème auquel il répond
 
-Gérer manuellement des [microservices](/fr/microservices-architecture), la sécurité, et la communication réseaux à grande échelle — et des [systèmes distribués](/fr/distributed-systems) en général — est compliqué, pour ne pas dire impossible.
+Gérer manuellement des [microservices](/fr/microservices-architecture/), la sécurité, et la communication réseaux à grande échelle — et des [systèmes distribués](/fr/distributed-systems/) en général — est compliqué, pour ne pas dire impossible.
 L'orchestration de conteneurs permet aux utilisateurs d'automatiser toutes ces tâches de gestion.
 
 ## Quelle en est l'utilité

--- a/content/fr/container-orchestration.md
+++ b/content/fr/container-orchestration.md
@@ -4,7 +4,7 @@ status: Completed
 category: Concept
 ---
 
-L'orchestration de [Conteneurs](/fr/container/) fait référence à la gestion et à l'automatisation du cycle de vie d'applications [conteneurisées](/containerization/) au sein d'environnements dynamiques.
+L'orchestration de [Conteneurs](/fr/container/) fait référence à la gestion et à l'automatisation du cycle de vie d'applications [conteneurisées](/fr/containerization/) au sein d'environnements dynamiques.
 Réalisée à l'aide d'un orchestrateur de conteneurs (la plupart du temps, [Kubernetes](/fr/kubernetes/)), elle permet les déploiements, le passage à l'échelle (automatique), (l'auto-)remédiation et le monitoring.
 L'orchestration est une métaphore:
 L'outil d'orchestration dirige les conteneurs tel un chef d'orchestre, s'assurant que chaque conteneur (ou musicien) fait ce qu'il doit faire.


### PR DESCRIPTION
- Contributes to #3190
- Normalizes links, adding a trailing slash, as reported by the link checker
- Adds a missing link to the containerization page -- so as to match the English base language version of the page
- There are no other changes. Paragraphs were line-wrapped à la Prettier.