### PR TITLE
Don't store search increments in the browser history

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -55,7 +55,7 @@
 
 		var newUrl = baseUrl + "?" + urlParams.toString();
 		// Update the browser history (optional)
-		window.history.pushState({}, null, newUrl);
+		history.replaceState(null, '', newUrl);
 	}
 	</script>
 	


### PR DESCRIPTION
Currently when you refine your search term, each additional edit get stored in the browser history so that clicking Back will only take you to the previous edit. This eliminates that storage so that clicking Back will take the user to the previous page.