### PR TITLE
[EN] Update `Serverless` - fix links

### DIFF
--- a/content/en/serverless.md
+++ b/content/en/serverless.md
@@ -9,12 +9,12 @@ tags: ["architecture", "", ""]
 Serverless Computing [abstracts](/abstraction/) servers away from the user.
 Operational management falls to the service provider, including handling physical machines and VM provisioning.
 Service providers can be public cloud entities or internal IT departments serving their development teams.
-These providers offer user interfaces such as SDKs, CLIs, or OCI-compliant runtimes, focusing on code and deployment tasks.
+These providers offer user interfaces such as SDKs, CLIs, or OCI-compliant [runtimes](/runtime/), focusing on code and deployment tasks.
 Charges are based on a pay-per-use model.
 [Scaling](/scalability/) and resource provisioning for computing, storage, or networking are automatically adjusted based on application demand without user intervention.
 A serverless platform provider consolidates resources to serve multiple users on a single physical machine, ensuring isolation through virtualization, especially with [VMs](/virtual-machine/).
 
-Serverless is a comprehensive term encompassing services with these attributes, extending from [Platform-as-a-Service (PaaS)](/platform-as-a-service/) to [Software-as-a-Service (SaaS)](/software-as-a-service/).
+Serverless is a comprehensive term encompassing services with these attributes, extending from Platform-as-a-Service (PaaS) to Software-as-a-Service (SaaS).
 
 ## Problem it addresses
 


### PR DESCRIPTION
### Describe your changes

Hello, I'm updating the French translation of this term and I noticed 2 little problems with the links:

* Line 12: a page about OCI runtime exist, it would be nice to link it.
* Line 17: Both links are dead as PaaS and SaaS are deprecated terms. I thought deprecated terms were still accessible by direct links, but it gives a "Oops, this page doesn't exist" in the English version.  So I removed the links.

Thank you

### Related issue number or link (ex: `resolves #issue-number`)

This is a minor fix, so I didn't open an issue. Tell me if I need to open one.  

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
