### PR TITLE
[EN] update FaaS

### DIFF
--- a/content/en/function-as-a-service.md
+++ b/content/en/function-as-a-service.md
@@ -8,7 +8,7 @@ tags: ["infrastructure", "", ""]
 Function as a Service (FaaS) is a [cloud computing](/cloud-computing/) model that provides a platform for executing event-triggered functions, allowing for automatic scaling without manual intervention.
 At its essence, FaaS enables the deployment of individual functions that are activated by specific events, operate on a short-term basis, and then shut down, ensuring resources are not wasted.
 This model supports an [autoscaling](/auto-scaling/) feature, enabling a function instance to be initiated per request and terminated post-execution, emphasizing its [stateless](/stateless-apps/) nature.
-Consequently, FaaS platforms can implement a true pay-as-you-go billing approach, eliminating costs when functions are dormant, distinguishing it from other models like [Platform as a Service (PaaS)](/platform-as-a-service/), which require continuous resource availability.
+Consequently, FaaS platforms can implement a true pay-as-you-go billing approach, eliminating costs when functions are dormant, distinguishing it from other models like Platform as a Service (PaaS), which require continuous resource availability.
 
 ## Problem it addresses
 
@@ -23,6 +23,6 @@ FaaS gives developers an [abstraction](/abstraction/) for running web applicatio
 For example, an action such as uploading a file could trigger custom code that transcodes the file into various formats.
 The FaaS infrastructure automatically adjusts resources to match demand, freeing developers from the complexities of coding for [scalability](/scalability/).
 Charges apply solely for the duration of computation, ensuring no costs accrue when functions are inactive.
-	
+
 For more information, refer to the [Serverless](/serverless/) glossary entry.
 Although "serverless" and "FaaS" are often used as interchangeable terms, they embody distinct concepts.


### PR DESCRIPTION
### Describe your changes
Removed link to PaaS as it is a deprecated term. 
Removed useless spaces on line 26 
Added a new line at the end of line 28

### Related issue number or link (ex: `resolves #issue-number`)
I noticed that while localizing FaaS to French in https://github.com/cncf/glossary/pull/3297

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
