### PR TITLE
Scroll into view sidebar

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -77,13 +77,17 @@
 {{- end }}
 
 <script>
-	document.addEventListener("DOMContentLoaded", function () {
-	  const activeLink = document.querySelector(".td-sidebar-nav__section .active");
-	  if (activeLink) {
-		activeLink.scrollIntoView({
-		  behavior: "smooth",
-		  block: "center",
-		});
-	  }
-	});
-	</script>
+document.addEventListener("DOMContentLoaded", function () {
+  const sidebar = document.querySelector("#td-section-nav"); 
+  const activeLink = sidebar?.querySelector(".td-sidebar-nav__section .active"); 
+
+  if (activeLink && sidebar) {
+    const sidebarTop = sidebar.scrollTop; 
+    const activeLinkOffset = activeLink.offsetTop; 
+    sidebar.scrollTo({
+      top: activeLinkOffset - sidebar.clientHeight / 2 + activeLink.offsetHeight / 2,
+      behavior: "smooth",
+    });
+  }
+});
+</script>

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -13,7 +13,7 @@
   </form>
   <div class="search-by-tag">
     <a href="{{ relref . "/tags" }}">{{ T "ui_or_search_by_tags" }}</a>
-  </div>  
+  </div>
   {{ else -}}
   <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
@@ -75,3 +75,15 @@
   {{- end }}
 </li>
 {{- end }}
+
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+	  const activeLink = document.querySelector(".td-sidebar-nav__section .active");
+	  if (activeLink) {
+		activeLink.scrollIntoView({
+		  behavior: "smooth",
+		  block: "center",
+		});
+	  }
+	});
+	</script>


### PR DESCRIPTION
### Describe your changes

Due to the length of the sidebar content, it was commented that finding the next/previous pages in the sidebar was difficult (see #3209). This PR keeps the current active item in view in the sidebar, so navigating should be easier.

Preview: 

https://github.com/user-attachments/assets/7255dabc-a332-40a9-b592-6de3d0c63f59

### Related issue number or link (ex: `resolves #issue-number`)

Resolves #3209 

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.