### PR TITLE
[editorial] Use slack.cncf.io as canonical URL

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,43 +1,43 @@
 ---
-title: "Cloud Native Glossary"
+title: Cloud Native Glossary
 status: Completed
 ---
 
 # Cloud Native Glossary
 
-The Cloud Native Glossary aims to make the cloud native space — which is notorious for its complexity — simpler for people by making it easier to understand, 
-not only for technologists but also for people on the business side. 
-To achieve that, we focus on simplicity (e.g., simple language free from buzzwords, examples anyone using technology can relate to, leaving unnecessary details out). 
-The Glossary is a project led by the CNCF Business Value Subcommittee (BVS). 
+The Cloud Native Glossary aims to make the cloud native space — which is notorious for its complexity — simpler for people by making it easier to understand,
+not only for technologists but also for people on the business side.
+To achieve that, we focus on simplicity (e.g., simple language free from buzzwords, examples anyone using technology can relate to, leaving unnecessary details out).
+The Glossary is a project led by the CNCF Business Value Subcommittee (BVS).
 
 <p><img class="mt-3" src="/images/homepage/kubecon.jpg" alt="People watching a Kubecon presentation"></p>
 
 ## Contributing
 
-Everybody is invited to suggest changes, additions, and improvements to the Cloud Native Glossary. 
-We employ a community-driven process governed by the CNCF to develop and improve upon this shared lexicon. 
-This Glossary provides a vendor-neutral platform to organize a shared vocabulary around cloud native technologies. 
+Everybody is invited to suggest changes, additions, and improvements to the Cloud Native Glossary.
+We employ a community-driven process governed by the CNCF to develop and improve upon this shared lexicon.
+This Glossary provides a vendor-neutral platform to organize a shared vocabulary around cloud native technologies.
 Contributions are welcome from all participants who abide by the project's purpose and charter.
 
 Anyone wishing to contribute may submit a GitHub issue or create a pull request.
-Please ensure you follow the [Style Guide](/style-guide/), read the [How To Contribute](/contribute/) doc, join the [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) workspace, and join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel.
+Please ensure you follow the [Style Guide](/style-guide/), read the [How To Contribute](/contribute/) doc, join the [CNCF Slack](https://slack.cncf.io) workspace, and join the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel.
 There is also a [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) channel for those who want to help translate the glossary into their native language.
 
 ## Acknowledgements
 
-The Cloud Native Glossary was initiated by the CNCF Marketing Committee (Business Value Subcommittee) and includes contributions from 
-[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/), 
-[Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/), 
-[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk), 
-[Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/), 
-[Katelin Ramer](https://www.linkedin.com/in/katelinramer/), 
-[Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca), 
-and many more contributors. 
+The Cloud Native Glossary was initiated by the CNCF Marketing Committee (Business Value Subcommittee) and includes contributions from
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/),
+[Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/),
+[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk),
+[Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/),
+[Katelin Ramer](https://www.linkedin.com/in/katelinramer/),
+[Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca),
+and many more contributors.
 For a complete contributor list, please refer to [this GitHub page](https://github.com/cncf/glossary/graphs/contributors).
 
-The Glossary is maintained by 
+The Glossary is maintained by
 [Seokho Son](https://www.linkedin.com/in/seokho-son/),
-[Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/), 
+[Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/),
 [Jihoon Seo](https://www.linkedin.com/in/jihoon-seo/),
 [Nate W.](https://www.linkedin.com/in/nate-double-u/),
 and [Jorge Castro](https://www.linkedin.com/in/jorge-castro2112/).
@@ -49,5 +49,5 @@ for their invaluable contributions over the years.
 
 ## License
 
-All code contributions are under the Apache 2.0 license. 
+All code contributions are under the Apache 2.0 license.
 Documentation is distributed under CC BY 4.0.


### PR DESCRIPTION
- For context, see https://github.com/cncf/techdocs/pull/300
- Uses slack.cncf.io instead of communityinviter.com/apps/cloud-native/cncf
- Other minor copyedit.

/cc @nate-double-u 