### PR TITLE
fix: rename tag to Fundamentos

### DIFF
--- a/content/es/abstraction.md
+++ b/content/es/abstraction.md
@@ -2,7 +2,7 @@
 title: Abstracción
 status: Completed
 category: Propiedad
-tags: ["fundamental", "", ""]
+tags: ["básico", "", ""]
 ---
 
 En el contexto de la informática, una abstracción es una representación que

--- a/content/es/abstraction.md
+++ b/content/es/abstraction.md
@@ -2,7 +2,7 @@
 title: Abstracción
 status: Completed
 category: Propiedad
-tags: ["básico", "", ""]
+tags: ["fundamentos", "", ""]
 ---
 
 En el contexto de la informática, una abstracción es una representación que

--- a/content/es/application-programming-interface.md
+++ b/content/es/application-programming-interface.md
@@ -2,7 +2,7 @@
 title: Interfaz de programación de aplicaciones (API)
 status: Completed
 category: Tecnología
-tags: ["arquitectura", "fundamento", ""]
+tags: ["arquitectura", "básico", ""]
 ---
 
 Una API es una manera en la que los programas de computadoras interactúan entre sí.

--- a/content/es/application-programming-interface.md
+++ b/content/es/application-programming-interface.md
@@ -2,7 +2,7 @@
 title: Interfaz de programación de aplicaciones (API)
 status: Completed
 category: Tecnología
-tags: ["arquitectura", "básico", ""]
+tags: ["arquitectura", "fundamentos", ""]
 ---
 
 Una API es una manera en la que los programas de computadoras interactúan entre sí.

--- a/content/es/client-server-architecture.md
+++ b/content/es/client-server-architecture.md
@@ -2,7 +2,7 @@
 title: Arquitectura Cliente-Servidor
 status: Completed
 category: Concepto
-tags: ["arquitectura", "fundamento", ""]
+tags: ["arquitectura", "básico", ""]
 ---
 
 En una arquitectura cliente-servidor, la lógica (o código) que constituye una aplicación se divide en dos o más componentes:

--- a/content/es/client-server-architecture.md
+++ b/content/es/client-server-architecture.md
@@ -2,7 +2,7 @@
 title: Arquitectura Cliente-Servidor
 status: Completed
 category: Concepto
-tags: ["arquitectura", "básico", ""]
+tags: ["arquitectura", "fundamentos", ""]
 ---
 
 En una arquitectura cliente-servidor, la lógica (o código) que constituye una aplicación se divide en dos o más componentes:

--- a/content/es/cloud-computing.md
+++ b/content/es/cloud-computing.md
@@ -2,7 +2,7 @@
 title: Computación en la Nube
 status: Completed
 category: Concepto
-tags: ["infraestructura", "fundamento", ""]
+tags: ["infraestructura", "básico", ""]
 ---
 
 La computación en la nube es un modelo que ofrece recursos informáticos como capacidades de CPU, red y disco bajo demanda a través de Internet.

--- a/content/es/cloud-computing.md
+++ b/content/es/cloud-computing.md
@@ -2,7 +2,7 @@
 title: Computación en la Nube
 status: Completed
 category: Concepto
-tags: ["infraestructura", "básico", ""]
+tags: ["infraestructura", "fundamentos", ""]
 ---
 
 La computación en la nube es un modelo que ofrece recursos informáticos como capacidades de CPU, red y disco bajo demanda a través de Internet.

--- a/content/es/cloud-native-apps.md
+++ b/content/es/cloud-native-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones Nativas para la Nube
 status: Completed
 category: Concepto
-tags: ["aplicación", "fundamento", ""]
+tags: ["aplicación", "básico", ""]
 ---
 
 Las aplicaciones nativas para la nube están diseñadas específicamente para aprovechar las innovaciones en [computación en la nube](/es/cloud-computing/).

--- a/content/es/cloud-native-apps.md
+++ b/content/es/cloud-native-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones Nativas para la Nube
 status: Completed
 category: Concepto
-tags: ["aplicación", "básico", ""]
+tags: ["aplicación", "fundamentos", ""]
 ---
 
 Las aplicaciones nativas para la nube están diseñadas específicamente para aprovechar las innovaciones en [computación en la nube](/es/cloud-computing/).

--- a/content/es/cloud-native-tech.md
+++ b/content/es/cloud-native-tech.md
@@ -2,7 +2,7 @@
 title: Tecnología Nativa para la Nube
 status: Completed
 category: Concepto
-tags: ["fundamental", "", ""]
+tags: ["básico", "", ""]
 ---
 
 Las tecnologías nativas para la nube, también denominadas como stack nativo para la nube,

--- a/content/es/cloud-native-tech.md
+++ b/content/es/cloud-native-tech.md
@@ -2,7 +2,7 @@
 title: Tecnología Nativa para la Nube
 status: Completed
 category: Concepto
-tags: ["básico", "", ""]
+tags: ["fundamentos", "", ""]
 ---
 
 Las tecnologías nativas para la nube, también denominadas como stack nativo para la nube,

--- a/content/es/cluster.md
+++ b/content/es/cluster.md
@@ -2,7 +2,7 @@
 title: Clúster
 status: Completed
 category: Concepto
-tags: ["infraestructura", "fundamento", ""]
+tags: ["infraestructura", "básico", ""]
 ---
 
 Un clúster es un grupo de ordenadores o aplicaciones que trabajan juntos hacia un objetivo común.

--- a/content/es/cluster.md
+++ b/content/es/cluster.md
@@ -2,7 +2,7 @@
 title: Clúster
 status: Completed
 category: Concepto
-tags: ["infraestructura", "básico", ""]
+tags: ["infraestructura", "fundamentos", ""]
 ---
 
 Un clúster es un grupo de ordenadores o aplicaciones que trabajan juntos hacia un objetivo común.

--- a/content/es/container.md
+++ b/content/es/container.md
@@ -2,7 +2,7 @@
 title: Contenedores
 status: Completed
 category: Tecnología
-tags: ["aplicación", "fundamento", ""]
+tags: ["aplicación", "básico", ""]
 ---
 
 Un contenedor es un proceso en ejecución con restricciones de recursos y capacidades administrado por el sistema operativo de una computadora.

--- a/content/es/container.md
+++ b/content/es/container.md
@@ -2,7 +2,7 @@
 title: Contenedores
 status: Completed
 category: Tecnología
-tags: ["aplicación", "básico", ""]
+tags: ["aplicación", "fundamentos", ""]
 ---
 
 Un contenedor es un proceso en ejecución con restricciones de recursos y capacidades administrado por el sistema operativo de una computadora.

--- a/content/es/data-center.md
+++ b/content/es/data-center.md
@@ -2,7 +2,7 @@
 title: Centro de Datos
 status: Completed
 category: Tecnología
-tags: ["infraestructura", "fundamento", ""]
+tags: ["infraestructura", "básico", ""]
 ---
 
 Un centro de datos es un edificio diseñado específicamente para almacenar computadoras, habitualmente referidas como servidores.

--- a/content/es/data-center.md
+++ b/content/es/data-center.md
@@ -2,7 +2,7 @@
 title: Centro de Datos
 status: Completed
 category: Tecnología
-tags: ["infraestructura", "básico", ""]
+tags: ["infraestructura", "fundamentos", ""]
 ---
 
 Un centro de datos es un edificio diseñado específicamente para almacenar computadoras, habitualmente referidas como servidores.

--- a/content/es/kubernetes.md
+++ b/content/es/kubernetes.md
@@ -2,7 +2,7 @@
 title: Kubernetes
 status: Completed
 category: Tecnología
-tags: ["infraestructura", "fundamento", ""]
+tags: ["infraestructura", "básico", ""]
 ---
 
 Kubernetes, comúnmente abreviado como K8s, es un orquestador de contenedores de código abierto.

--- a/content/es/kubernetes.md
+++ b/content/es/kubernetes.md
@@ -2,7 +2,7 @@
 title: Kubernetes
 status: Completed
 category: Tecnología
-tags: ["infraestructura", "básico", ""]
+tags: ["infraestructura", "fundamentos", ""]
 ---
 
 Kubernetes, comúnmente abreviado como K8s, es un orquestador de contenedores de código abierto.

--- a/content/es/loosely-coupled-architecture.md
+++ b/content/es/loosely-coupled-architecture.md
@@ -2,7 +2,7 @@
 title: Arquitectura débilmente acoplada
 status: Completed
 category: Propiedad
-tags: ["fundamento", "arquitectura", "propiedad"]
+tags: ["básico", "arquitectura", "propiedad"]
 ---
 
 

--- a/content/es/loosely-coupled-architecture.md
+++ b/content/es/loosely-coupled-architecture.md
@@ -2,7 +2,7 @@
 title: Arquitectura débilmente acoplada
 status: Completed
 category: Propiedad
-tags: ["básico", "arquitectura", "propiedad"]
+tags: ["fundamentos", "arquitectura", "propiedad"]
 ---
 
 

--- a/content/es/microservices-architecture.md
+++ b/content/es/microservices-architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Arquitectura de Microservicios
 status: Completed
-tags: ["arquitectura", "fundamento", ""]
+tags: ["arquitectura", "básico", ""]
 ---
 
 Una arquitectura de microservicios es un enfoque arquitectónico que divide las aplicaciones en (micro)[servicios](/es/service/) individuales e independientes, donde cada servicio se centra en una funcionalidad específica.

--- a/content/es/microservices-architecture.md
+++ b/content/es/microservices-architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Arquitectura de Microservicios
 status: Completed
-tags: ["arquitectura", "básico", ""]
+tags: ["arquitectura", "fundamentos", ""]
 ---
 
 Una arquitectura de microservicios es un enfoque arquitectónico que divide las aplicaciones en (micro)[servicios](/es/service/) individuales e independientes, donde cada servicio se centra en una funcionalidad específica.

--- a/content/es/monolithic-apps.md
+++ b/content/es/monolithic-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones monolíticas
 status: Completed
 category: Concepto
-tags: ["arquitectura", "fundamento", ""]
+tags: ["arquitectura", "básico", ""]
 ---
 
 Una aplicación monolítica contiene toda la funcionalidad en un único programa desplegable.

--- a/content/es/monolithic-apps.md
+++ b/content/es/monolithic-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones monolíticas
 status: Completed
 category: Concepto
-tags: ["arquitectura", "básico", ""]
+tags: ["arquitectura", "fundamentos", ""]
 ---
 
 Una aplicación monolítica contiene toda la funcionalidad en un único programa desplegable.

--- a/content/es/nodes.md
+++ b/content/es/nodes.md
@@ -2,7 +2,7 @@
 title: Nodos
 status: Completed
 category: Tecnología
-tags: ["infraestructura", "fundamento", ""]
+tags: ["infraestructura", "básico", ""]
 ---
 
 Un nodo es un servidor que trabaja en conjunto a otros servidores, o nodos, para realizar una tarea común.

--- a/content/es/nodes.md
+++ b/content/es/nodes.md
@@ -2,7 +2,7 @@
 title: Nodos
 status: Completed
 category: Tecnología
-tags: ["infraestructura", "básico", ""]
+tags: ["infraestructura", "fundamentos", ""]
 ---
 
 Un nodo es un servidor que trabaja en conjunto a otros servidores, o nodos, para realizar una tarea común.

--- a/content/es/platform-as-a-service.md
+++ b/content/es/platform-as-a-service.md
@@ -2,7 +2,7 @@
 title: Plataforma como Servicio (PaaS)
 status: Deprecated
 category: Tecnología
-tags: ["fundamentos", "plataforma", ""]
+tags: ["básico", "plataforma", ""]
 ---
 
 Una plataforma como servicio, o PaaS, es una plataforma externa usada por los equipos de desarrollo de aplicaciones para desplegar y correr sus aplicaciones.

--- a/content/es/platform-as-a-service.md
+++ b/content/es/platform-as-a-service.md
@@ -2,7 +2,7 @@
 title: Plataforma como Servicio (PaaS)
 status: Deprecated
 category: Tecnología
-tags: ["básico", "plataforma", ""]
+tags: ["fundamentos", "plataforma", ""]
 ---
 
 Una plataforma como servicio, o PaaS, es una plataforma externa usada por los equipos de desarrollo de aplicaciones para desplegar y correr sus aplicaciones.

--- a/content/es/pod.md
+++ b/content/es/pod.md
@@ -2,7 +2,7 @@
 title: Pod
 status: Completed
 category: Concepto
-tags: ["infraestructura", "fundamento", ""]
+tags: ["infraestructura", "básico", ""]
 ---
 
 Dentro de un entorno de [Kubernetes](/es/kubernetes/), un Pod actúa como la unidad más básica desplegable. 

--- a/content/es/pod.md
+++ b/content/es/pod.md
@@ -2,7 +2,7 @@
 title: Pod
 status: Completed
 category: Concepto
-tags: ["infraestructura", "básico", ""]
+tags: ["infraestructura", "fundamentos", ""]
 ---
 
 Dentro de un entorno de [Kubernetes](/es/kubernetes/), un Pod actúa como la unidad más básica desplegable. 

--- a/content/es/portability.md
+++ b/content/es/portability.md
@@ -2,7 +2,7 @@
 title: Portabilidad
 status: Completed
 category: Propiedad
-tags: ["fundamento", "propiedad", ""]
+tags: ["básico", "propiedad", ""]
 ---
 
 La portabilidad es una característica del software, siendo una forma de reutilización que ayuda a evitar el "bloqueo" de ciertos entornos operativos,

--- a/content/es/portability.md
+++ b/content/es/portability.md
@@ -2,7 +2,7 @@
 title: Portabilidad
 status: Completed
 category: Propiedad
-tags: ["básico", "propiedad", ""]
+tags: ["fundamentos", "propiedad", ""]
 ---
 
 La portabilidad es una característica del software, siendo una forma de reutilización que ayuda a evitar el "bloqueo" de ciertos entornos operativos,

--- a/content/es/reliability.md
+++ b/content/es/reliability.md
@@ -2,7 +2,7 @@
 title: Fiabilidad
 status: Completed
 category: Propiedad
-tags: ["fundamento", "propiedad", ""]
+tags: ["básico", "propiedad", ""]
 ---
 
 Desde una perspectiva nativa a la nube, fiabilidad se refiere a qué tan bien un sistema responde ante las fallas. 

--- a/content/es/reliability.md
+++ b/content/es/reliability.md
@@ -2,7 +2,7 @@
 title: Fiabilidad
 status: Completed
 category: Propiedad
-tags: ["básico", "propiedad", ""]
+tags: ["fundamentos", "propiedad", ""]
 ---
 
 Desde una perspectiva nativa a la nube, fiabilidad se refiere a qué tan bien un sistema responde ante las fallas. 

--- a/content/es/scalability.md
+++ b/content/es/scalability.md
@@ -2,7 +2,7 @@
 title: Escalabilidad
 status: Completed
 category: Propiedad
-tags: ["fundamento", "propiedad", ""]
+tags: ["básico", "propiedad", ""]
 ---
 
 La escalabilidad se refiere a que tan bien puede crecer un sistema.

--- a/content/es/scalability.md
+++ b/content/es/scalability.md
@@ -2,7 +2,7 @@
 title: Escalabilidad
 status: Completed
 category: Propiedad
-tags: ["básico", "propiedad", ""]
+tags: ["fundamentos", "propiedad", ""]
 ---
 
 La escalabilidad se refiere a que tan bien puede crecer un sistema.

--- a/content/es/service.md
+++ b/content/es/service.md
@@ -2,7 +2,7 @@
 title: Servicio
 status: Completed
 category: Concepto
-tags: ["aplicación", "fundamento", ""]
+tags: ["aplicación", "básico", ""]
 ---
 
 Es importante señalar que en TI, el término 'servicio' tiene diversos significados.

--- a/content/es/service.md
+++ b/content/es/service.md
@@ -2,7 +2,7 @@
 title: Servicio
 status: Completed
 category: Concepto
-tags: ["aplicación", "básico", ""]
+tags: ["aplicación", "fundamentos", ""]
 ---
 
 Es importante señalar que en TI, el término 'servicio' tiene diversos significados.

--- a/content/es/software-as-a-service.md
+++ b/content/es/software-as-a-service.md
@@ -3,7 +3,7 @@ Title: Software como Servicio (SaaS)
 Status: Deprecated
 Category: Tecnología
 draft: true
-tags: ["fundamento", "plataforma", ""]
+tags: ["básico", "plataforma", ""]
 ---
 
 El software como servicio (SaaS) permite a los usuarios conectarse y utilizar servicios basados en la nube a través de Internet.

--- a/content/es/software-as-a-service.md
+++ b/content/es/software-as-a-service.md
@@ -3,7 +3,7 @@ Title: Software como Servicio (SaaS)
 Status: Deprecated
 Category: Tecnología
 draft: true
-tags: ["básico", "plataforma", ""]
+tags: ["fundamentos", "plataforma", ""]
 ---
 
 El software como servicio (SaaS) permite a los usuarios conectarse y utilizar servicios basados en la nube a través de Internet.

--- a/content/es/stateful-apps.md
+++ b/content/es/stateful-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones con estado
 status: Completed
 category: Concepto
-tags: ["fundamento", "aplicación", ""]
+tags: ["básico", "aplicación", ""]
 ---
 
 Cuando hablamos de aplicaciones con estado (y [sin estado](/es/stateless-apps/)),

--- a/content/es/stateful-apps.md
+++ b/content/es/stateful-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones con estado
 status: Completed
 category: Concepto
-tags: ["básico", "aplicación", ""]
+tags: ["fundamentos", "aplicación", ""]
 ---
 
 Cuando hablamos de aplicaciones con estado (y [sin estado](/es/stateless-apps/)),

--- a/content/es/stateless-apps.md
+++ b/content/es/stateless-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones sin estado
 status: Feedback Appreciated
 category: Tecnología
-tags: ["fundamento", "aplicación", ""]
+tags: ["básico", "aplicación", ""]
 ---
 
 Una aplicación sin estado o independiente al estado, es la que no guarda ningún dato de sesión del cliente (estado) en el servidor donde la aplicación vive.

--- a/content/es/stateless-apps.md
+++ b/content/es/stateless-apps.md
@@ -2,7 +2,7 @@
 title: Aplicaciones sin estado
 status: Feedback Appreciated
 category: Tecnología
-tags: ["básico", "aplicación", ""]
+tags: ["fundamentos", "aplicación", ""]
 ---
 
 Una aplicación sin estado o independiente al estado, es la que no guarda ningún dato de sesión del cliente (estado) en el servidor donde la aplicación vive.

--- a/content/es/style-guide/_index.md
+++ b/content/es/style-guide/_index.md
@@ -99,7 +99,7 @@ Las etiquetas existentes son:
 
 - aplicación
 - arquitectura
-- fundamento
+- básico
 - infraestructura
 - metodología
 - redes

--- a/content/es/style-guide/_index.md
+++ b/content/es/style-guide/_index.md
@@ -34,7 +34,7 @@ Nuestro objetivo es facilitar la comprensión de términos nativos de nube a cua
 Por lo tanto, nos focalizamos en la simplicidad.
 Lo que significa utilizar lenguaje simple y conciso con ejemplos que cualquiera que usa tecnología pueda identificarse, pero también proveyendo un *contenido mínimo viable*, al menos desde un punto de vista técnico.
 No queremos ahorrar en contexto o ejemplos - que ayudan al lector a entender el concepto - pero si el detalle técnico no es necesario para entender lo explicado, no serán incluidos.
-El objetivo es no complicar las cosas. Una vez que el lector entienda el concepto básico, otros recursos ayudarán a ahondar.
+El objetivo es no complicar las cosas. Una vez que el lector entienda el concepto fundamental, otros recursos ayudarán a ahondar.
 Esa parte está fuera del control de este Glosario.
 
 ## Plantilla de definición
@@ -99,7 +99,7 @@ Las etiquetas existentes son:
 
 - aplicación
 - arquitectura
-- básico
+- fundamentos
 - infraestructura
 - metodología
 - redes

--- a/content/es/tightly-coupled-architectures.md
+++ b/content/es/tightly-coupled-architectures.md
@@ -2,7 +2,7 @@
 title: Arquitecturas fuertemente acopladas
 status: Completed
 category: Propiedad
-tags: ["fundamental", "arquitectura", "propiedad"]
+tags: ["básico", "arquitectura", "propiedad"]
 ---
 
 La arquitectura fuertemente acoplada es un tipo de arquitectura donde los componentes individuales de la aplicación son interdependientes 

--- a/content/es/tightly-coupled-architectures.md
+++ b/content/es/tightly-coupled-architectures.md
@@ -2,7 +2,7 @@
 title: Arquitecturas fuertemente acopladas
 status: Completed
 category: Propiedad
-tags: ["básico", "arquitectura", "propiedad"]
+tags: ["fundamentos", "arquitectura", "propiedad"]
 ---
 
 La arquitectura fuertemente acoplada es un tipo de arquitectura donde los componentes individuales de la aplicación son interdependientes 

--- a/content/es/virtual-machine.md
+++ b/content/es/virtual-machine.md
@@ -2,7 +2,7 @@
 title: Máquina Virtual
 status: Completed
 category: Tecnología
-tags: ["fundamento", "infraestructura", ""]
+tags: ["básico", "infraestructura", ""]
 ---
 
 Una máquina virtual (VM según sus siglas en Inglés) es una computadora y su sistema operativo

--- a/content/es/virtual-machine.md
+++ b/content/es/virtual-machine.md
@@ -2,7 +2,7 @@
 title: Máquina Virtual
 status: Completed
 category: Tecnología
-tags: ["básico", "infraestructura", ""]
+tags: ["fundamentos", "infraestructura", ""]
 ---
 
 Una máquina virtual (VM según sus siglas en Inglés) es una computadora y su sistema operativo

--- a/content/es/virtualization.md
+++ b/content/es/virtualization.md
@@ -2,7 +2,7 @@
 title: Virtualización
 status: completed
 category: Tecnología
-tags: ["fundamento", "infraestructura", "metodología"]
+tags: ["básico", "infraestructura", "metodología"]
 ---
 
 La virtualización, en el contexto de la computación nativa para la nube,

--- a/content/es/virtualization.md
+++ b/content/es/virtualization.md
@@ -2,7 +2,7 @@
 title: Virtualización
 status: completed
 category: Tecnología
-tags: ["básico", "infraestructura", "metodología"]
+tags: ["fundamentos", "infraestructura", "metodología"]
 ---
 
 La virtualización, en el contexto de la computación nativa para la nube,


### PR DESCRIPTION
### Describe your changes

Finds all occurrences of `Fundamental`, `Fundamento` or `Fundamentos` and replaces it with `Básico` as it's the Spanish equivalent. ~It also applies some format fixes like trailing spaces and bad tabulations.~

Resolves #3437

### Checklist before opening this PR
- [x] This PR does not contain plagiarism
- [x] I have signed off on all commits 
