### PR TITLE
adding hlipsig to the glossary as an EN Approver

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -44,7 +44,7 @@ collaborators:
   - username: nate-double-u
     permission: admin
 
-  - username: castrojo
+  - username: hlipsig
     permission: push
 
   # Localization approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,8 +10,8 @@
 
 
 # Approvers for English content
-/content/en/ @caniszczyk @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @Okabe-Junya
-/i18n/en.toml @caniszczyk @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @Okabe-Junya
+/content/en/ @caniszczyk @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @Okabe-Junya @hlipsig
+/i18n/en.toml @caniszczyk @seokho-son @iamNoah1 @jihoon-seo @nate-double-u @Okabe-Junya @hlipsig
 
 
 # These are the owners (approvers) for localization contents


### PR DESCRIPTION
### Describe your changes

Adding @hlipsig to the EN Approvers group.

/cc @seokho-son, @iamNoah1, @jihoon-seo, @Okabe-Junya 

Related: https://github.com/cncf/people/pull/972 (this fixes the codeowners file error)