### PR TITLE
Settings and initial contents for Vietnamese localization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -180,6 +180,14 @@ weight = 15
 [languages.ur.params]
 description = "CNCF کلاؤڈ کی مقامی لغت کا مقصد کلاؤڈ مقامی ایپلی کیشنز کے بارے میں بات کرتے وقت استعمال ہونے والی عام اصطلاحات کے حوالے کے طور پر استعمال کرنا ہے۔"
 
+[languages.vi]
+languageName = "Tiếng Việt (Vietnamese)"
+title = "Từ Điển Thuật Ngữ Cloud Native"
+contentDir = "content/vi"
+weight = 16
+[languages.vi.params]
+description = "Dự án Từ Điển Thuật Ngữ Cloud Native CNCF được xây dựng nhằm mục đích làm tài liệu tham khảo cho các thuật ngữ phổ biến khi thảo luận về các ứng dụng cloud native."
+
 [markup]
 [markup.goldmark]
 [markup.goldmark.renderer]

--- a/content/vi/_index.md
+++ b/content/vi/_index.md
@@ -1,0 +1,54 @@
+---
+title: Từ Điển Thuật Ngữ Cloud Native
+status: Completed
+---
+
+# Từ Điển Thuật Ngữ Cloud Native
+
+Từ Điển Thuật Ngữ Cloud Native hướng tới việc đơn giản hóa lĩnh vực cloud native - vốn nổi tiếng với sự phức tạp của nó - bằng cách giúp mọi người dễ dàng hiểu hơn, 
+không chỉ dành cho các chuyên gia công nghệ mà còn cho cả những người làm việc ở khía cạnh kinh doanh.
+Để đạt được điều đó, chúng tôi tập trung vào tính đơn giản (ví dụ: sử dụng ngôn ngữ đơn giản, tránh các thuật ngữ marketing, đưa ra các ví dụ thực tế mà bất kỳ ai sử dụng công nghệ đều có thể liên hệ được, và bỏ qua các chi tiết không cần thiết).
+Từ điển này là một dự án được dẫn dắt bởi Business Value Subcommittee (BVS) của CNCF.
+
+<p><img class="mt-3" src="/images/homepage/kubecon.jpg" alt="Mọi người đang xem một bài thuyết trình tại Kubecon"></p>
+
+## Đóng góp
+
+Mọi người đều được mời góp ý thay đổi, bổ sung và cải thiện Từ Điển Thuật Ngữ Cloud Native.
+Chúng tôi áp dụng quy trình phát triển dựa trên cộng đồng được quản lý bởi CNCF để phát triển và cải thiện bộ từ vựng chung này.
+Từ điển này cung cấp một nền tảng trung lập với nhà cung cấp để tổ chức vốn từ vựng chung về các công nghệ cloud native.
+Chúng tôi chào đón sự đóng góp từ tất cả những người tham gia tuân thủ mục đích và điều lệ của dự án.
+
+Bất kỳ ai muốn đóng góp đều có thể tạo GitHub issue hoặc pull request.
+Vui lòng đảm bảo tuân thủ [Quy tắc Trình bày](/style-guide/), đọc tài liệu [Cách Đóng góp](/contribute/), tham gia [Slack CNCF](https://slack.cncf.io), và tham gia kênh [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB).
+Ngoài ra còn có kênh [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) dành cho những người muốn giúp dịch từ điển sang ngôn ngữ mẹ đẻ của họ.
+
+## Lời cảm ơn
+
+Từ Điển Thuật Ngữ Cloud Native được khởi xướng bởi CNCF Marketing Committee (Business Value Subcommittee) và bao gồm những đóng góp từ
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/),
+[Chris Aniszczyk](https://www.linkedin.com/in/caniszczyk/),
+[Daniel Jones](https://www.linkedin.com/in/danieljoneseb/?originalSubdomain=uk),
+[Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/),
+[Katelin Ramer](https://www.linkedin.com/in/katelinramer/),
+[Mike Foster](https://www.linkedin.com/in/mfosterche/?originalSubdomain=ca),
+và nhiều người đóng góp khác.
+Để xem danh sách đầy đủ những người đóng góp, vui lòng tham khảo [trang GitHub này](https://github.com/cncf/glossary/graphs/contributors).
+
+Từ điển được duy trì bởi
+[Seokho Son](https://www.linkedin.com/in/seokho-son/),
+[Noah Ispas](https://www.linkedin.com/in/noah-ispas-0665b42a/),
+[Jihoon Seo](https://www.linkedin.com/in/jihoon-seo/),
+[Nate W.](https://www.linkedin.com/in/nate-double-u/)
+và [Junya Okabe](https://www.linkedin.com/in/junya-okabe/).
+
+[Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/en/),
+[Jason Morgan](https://www.linkedin.com/in/jasonmorgan2/) và
+[Jorge Castro](https://www.linkedin.com/in/jorge-castro2112/)
+là những Maintainer Danh dự, và chúng tôi vô cùng biết ơn
+những đóng góp quý báu của họ trong suốt những năm qua.
+
+## Giấy phép
+
+Tất cả các đóng góp về mã nguồn đều tuân theo giấy phép Apache 2.0.
+Tài liệu được phân phối theo giấy phép CC BY 4.0.

--- a/content/vi/contribute/_index.md
+++ b/content/vi/contribute/_index.md
@@ -1,0 +1,226 @@
+---
+title: Cách Đóng góp
+toc_hide: true
+status: Completed
+menu:
+  main:
+    weight: 10
+---
+
+## Chào mừng
+
+Chào mừng bạn đến với hướng dẫn đóng góp cho Từ Điển Thuật Ngữ Cloud Native, và cảm ơn sự quan tâm của bạn.
+Có nhiều cách để bạn có thể đóng góp cho dự án này, và chúng tôi sẽ trình bày chi tiết ở đây:
+
+1) [Làm việc với các issue hiện có](#work-on-an-existing-issue)
+2) [Đề xuất thuật ngữ mới](#propose-new-terms)
+3) [Cập nhật thuật ngữ hiện có](#update-an-existing-term)
+4) [Bản địa hóa từ điển](#help-localize-the-glossary)
+
+## Tổng quan về CNCF Glossary
+
+Mục tiêu của từ điển này là đơn giản hóa lĩnh vực cloud native - vốn nổi tiếng với sự phức tạp của nó - và từ đó giúp mọi người dễ tiếp cận hơn.
+
+Nội dung của Từ Điển Cloud Native được lưu trữ trong [kho lưu trữ GitHub này](https://github.com/cncf/glossary)
+nơi bạn có thể tìm thấy danh sách các [issue](https://github.com/cncf/glossary/issues), pull request ([PR](https://github.com/cncf/glossary/pulls)), và
+[thảo luận](https://github.com/cncf/glossary/discussions) về từ điển.
+
+## Ai có thể đóng góp?
+
+Cách bạn có thể tham gia vào dự án này phụ thuộc vào mức độ hiểu biết của bạn về cloud native.
+Việc đơn giản hóa các khái niệm phức tạp đòi hỏi kiến thức sâu rộng về chủ đề.
+Do đó, để đóng góp các thuật ngữ mới, bạn phải thành thạo về chúng.
+Những người đóng góp thường là các kỹ sư đã làm việc với các công nghệ này trong một thời gian hoặc các học giả tập trung vào cloud native.
+
+Kiến thức đó là cần thiết vì việc giải thích các khái niệm phức tạp bằng từ ngữ đơn giản là _thực sự_ khó.
+Và mặc dù kết quả cuối cùng dễ hiểu, thân thiện với người dùng có vẻ dễ dàng, nhưng để đạt được sự đơn giản mong muốn là kết quả của sự làm việc chăm chỉ và sự hợp tác giữa các chuyên gia cloud native.
+
+Nếu bạn chưa phải là chuyên gia cloud native nhưng vẫn muốn đóng góp, chúng tôi khuyên bạn nên hợp tác với một người đã có kinh nghiệm.
+Khi chuyên gia đó tin tưởng rằng thuật ngữ mô tả chính xác khái niệm, bạn đã sẵn sàng cho đóng góp đầu tiên của mình vào Từ điển.
+
+Nỗ lực bản địa hóa là nơi những người mới bắt đầu thông thạo ngôn ngữ khác có thể đóng góp có giá trị cho Từ điển.
+Với các định nghĩa bằng tiếng Anh đã có sẵn, những người đóng góp ít kinh nghiệm hơn có thể bản địa hóa các thuật ngữ sang ngôn ngữ mục tiêu.
+Bạn có thể tham gia vào một nhóm bản địa hóa hiện có hoặc tạo một nhóm mới.
+Đọc phần [Giúp bản địa hóa từ điển](#help-localize-the-glossary) của hướng dẫn này để tìm hiểu cách bắt đầu.
+
+## Trước khi bạn bắt đầu
+
+Trước khi bắt đầu hành trình đóng góp cho Từ điển, hãy đảm bảo hoàn thành các bước sau:
+
+1. Tạo [tài khoản GitHub](https://docs.github.com/en/get-started/signing-up-for-github/signing-up-for-a-new-github-account), nếu bạn chưa có.
+2. Ký [Thỏa thuận Cấp phép Cộng tác viên](https://docs.linuxfoundation.org/lfx/easycla/v2-current/contributors) (CLA).
+3. [Xác minh chữ ký commit của bạn](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+4. Bật [chế độ cảnh giác](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits#about-vigilant-mode) trong tài khoản GitHub của bạn để hiển thị trạng thái "Đã xác minh" trên các commit của bạn.
+
+## Các phương pháp hay {#best-practices}
+
+Để tạo điều kiện thuận lợi cho quá trình đánh giá, vui lòng sử dụng [ngắt dòng theo ngữ nghĩa](https://sembr.org/) (ví dụ: mỗi câu một dòng).
+Chúng tôi khuyên bạn nên tham khảo [markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/) này
+để định dạng văn bản Markdown chính xác trong GitHub (ví dụ: hyperlink, in đậm, in nghiêng).
+Và khi đặt tên file .md, vui lòng sử dụng chữ thường và dấu gạch ngang thay vì khoảng trắng để phân tách các từ và tránh dấu ngoặc đơn.
+
+## Quy tắc Trình bày
+
+Đọc [Quy tắc Trình bày](/style-guide/) của chúng tôi để hiểu các hướng dẫn về định dạng và viết tài liệu và làm cho quá trình đóng góp hiệu quả hơn.
+
+## Tham gia cộng đồng Glossary! {#join-the-glossary-community}
+
+Kết nối với các maintainer và những người đóng góp khác trong kênh [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) trên Slack CNCF
+— chúng tôi rất muốn gặp bạn!
+
+## Làm việc với các issue hiện có {#work-on-an-existing-issue}
+
+Truy cập [Glossary GitHub repo issues](https://github.com/cncf/glossary/issues) để tìm danh sách các issue có sẵn.
+Bạn có thể sử dụng nhãn (ví dụ: English language, help needed, good first issue) để lọc các issue.
+
+![Issue và nhãn](/images/how-to/issue-and-labels.png)
+
+Hãy chắc chắn rằng thuật ngữ bạn chọn chưa được giao cho ai.
+Ví dụ, ở đây bạn có thể thấy ba thuật ngữ đầu tiên còn trống trong khi thuật ngữ thứ tư đã được giao.
+
+![giao một thuật ngữ](/images/how-to/howto-04.png)
+
+Sau khi chọn một thuật ngữ để làm việc, hãy bình luận vào issue đó.
+
+![Nhận một issue](/images/how-to/claiming-an-issue.png)
+
+Ngoài ra, thông báo cho các maintainer trên kênh [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) của Slack CNCF và
+gắn thẻ _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_ và/hoặc _@Junya Okabe_ để đảm bảo họ không bỏ sót.
+
+Đối với các bước tiếp theo, vui lòng tham khảo phần [Gửi một thuật ngữ mới (tạo PR)](#submitting-a-new-term).
+
+**Lưu ý**: bạn có thể bắt đầu làm việc với một issue sau khi các maintainer giao nó cho bạn.
+Bạn chỉ có thể nhận một thuật ngữ tại một thời điểm.
+Làm việc với nhiều thuật ngữ là tuần tự, bạn phải hoàn thành một thuật ngữ trước khi nhận thuật ngữ tiếp theo.
+
+## Đề xuất thuật ngữ mới {#propose-new-terms}
+
+Bạn có thể đề xuất một thuật ngữ mới để người khác làm việc hoặc tự tạo một định nghĩa mới.
+Dù là cách nào, bạn sẽ bắt đầu bằng việc [tạo một issue](#creating-an-issue).
+Để được thêm vào từ điển, mọi thuật ngữ mới phải đáp ứng [định nghĩa cloud native của CNCF](https://github.com/cncf/toc/blob/main/DEFINITION.md).
+Ngoại lệ duy nhất là các thuật ngữ nền tảng cần thiết để hiểu các khái niệm cloud native.
+
+Dưới đây là hướng dẫn từng bước cho những người không quen với GitHub.
+**Nếu bạn là GitHub Pro**, vui lòng _đọc_ hướng dẫn này để thu thập đủ thông tin về các chủ đề sau:
+
+1. Tìm mẫu cho issue và thuật ngữ mới.
+2. Nhận (claim) issue.
+3. Xử lý lỗi [kiểm tra chính tả](#spell-check).
+
+### Tạo một issue {#creating-an-issue}
+
+Truy cập [Glossary GitHub repo](https://github.com/cncf/glossary/issues) issues và nhấp vào "New issue".
+
+![issues](/images/how-to/howto-01.png)
+
+Chọn "Request to add a new term (English)" từ danh sách mẫu.
+
+![templates](/images/how-to/english-issue-template.jpg)
+
+Thêm từ bạn đang đề xuất, trả lời các câu hỏi, đánh dấu vào các ô, và nhấn "Submit new issue".
+Nếu bạn chỉ đề xuất một thuật ngữ mới, bạn đã hoàn thành! Nếu bạn muốn làm việc với định nghĩa, hãy tiếp tục đọc.
+
+### Phân loại issue của bạn {#triaging-your-issue}
+
+Tiếp theo, các maintainer sẽ phân loại issue.
+Điều đó có nghĩa là họ sẽ đánh giá xem thuật ngữ có nên là một phần của Từ điển hay không.
+Không phải mọi thuật ngữ đều được chấp nhận. Để được đưa vào Từ điển, chúng phải là các khái niệm cloud native đã được thiết lập và được sử dụng rộng rãi.
+
+Vui lòng thông báo cho các maintainer rằng bạn đã đề xuất một thuật ngữ mới trên Slack và gắn thẻ _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_ và/hoặc _@Junya Okabe_ để họ không bỏ sót.
+Nếu bạn muốn làm việc với định nghĩa, hãy cho các maintainer biết và họ sẽ giao nó cho bạn.
+
+### Gửi một thuật ngữ mới (tạo PR) {#submitting-a-new-term}
+
+Như đã nêu trong [Quy tắc Trình bày](/style-guide/) của chúng tôi, chúng tôi khuyến nghị bắt đầu với tài liệu Google hoặc Word.
+
+Khi thuật ngữ đã sẵn sàng để gửi, hãy vào content (dưới <>code)...
+
+![content](/images/how-to/howto-05.png)
+
+...sau đó "en" (cho tiếng Anh) hoặc hai chữ cái đầu tiên của ngôn ngữ bạn đang đóng góp...
+
+![thư mục ngôn ngữ](/images/how-to/howto-06.png)
+
+...và chọn `_TEMPLATE.md`
+
+![template](/images/how-to/howto-07.png)
+
+Sao chép nội dung...
+
+![sao chép nội dung](/images/how-to/howto-08.png)
+
+...và quay lại thư mục "en". Nhấp vào "Add file" và chọn "Create new file".
+
+![tạo file mới](/images/how-to/howto-09.png)
+
+Thêm tên của thuật ngữ vào URL như được mô tả trong phần [Các phương pháp hay](#best-practices).
+Thêm phần mở rộng .md vào cuối tên (không có phần mở rộng này bạn sẽ không thể xem trước file của mình).
+Bây giờ dán nội dung mẫu vào phần bên dưới. Sao chép và dán văn bản định nghĩa của bạn vào file.
+Để xác minh bạn đã sử dụng Markdown như được mô tả trong phần [Các phương pháp hay](#best-practices), nhấp vào "Preview".
+
+![hoàn thiện thuật ngữ](/images/how-to/howto-10.png)
+
+Cuộn xuống và đặt tên cho file commit mới. Nhấn "Commit new file" khi bạn đã sẵn sàng gửi
+và...
+
+![commit file mới](/images/how-to/howto-11.png)
+
+...bây giờ bạn đã sẵn sàng để tạo PR mới:
+
+![tạo pr](/images/how-to/howto-12.png)
+
+Sau khi nhấn nút "Create pull request", PR của bạn sẽ hiển thị trong tab "Pull requests".
+
+![prs](/images/how-to/howto-13.png)
+
+## Cập nhật thuật ngữ hiện có {#update-an-existing-term}
+
+Để cập nhật một thuật ngữ hiện có, bạn có thể yêu cầu thay đổi bằng cách tạo issue
+hoặc tự mình làm việc với các thay đổi và gửi PR.
+
+### Yêu cầu thay đổi qua issue {#request-a-change-via-an-issue}
+
+Nếu bạn muốn báo cáo vấn đề với một thuật ngữ, bạn có thể sử dụng tùy chọn "Report issue" của trang web CNCF Glossary.
+Định vị đến trang CNCF của khái niệm bạn muốn báo cáo và nhấp vào "Report issue".
+Thao tác này sẽ tự động mở một issue cho bạn
+
+![báo cáo vấn đề](/images/how-to/howto-14.png)
+
+Vui lòng mô tả đề xuất của bạn và lý do tại sao chúng cần thiết. Nhấn submit, và xong.
+
+![gửi issue](/images/how-to/howto-15.png)
+
+### Cập nhật thuật ngữ trực tiếp {#update-a-term-directly}
+
+Để sửa đổi một thuật ngữ và gửi đề xuất của bạn, nhấp vào "Edit this page."
+
+![chỉnh sửa trang này](/images/how-to/howto-16.png)
+
+Thao tác này sẽ mở trang GitHub của thuật ngữ. Thực hiện thay đổi của bạn và tạo PR.
+Vui lòng tham khảo phần [Các phương pháp hay](#best-practices) ở trên
+và đọc [Quy tắc Trình bày](/style-guide/) của chúng tôi để đảm bảo bạn tuân thủ các hướng dẫn của chúng tôi.
+
+## Giúp bản địa hóa từ điển {#help-localize-the-glossary}
+
+Để giúp bản địa hóa từ điển sang một ngôn ngữ mục tiêu, vui lòng tham gia kênh [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) trên Slack CNCF và gửi tin nhắn cho chúng tôi.
+Bạn có thể tham gia một nhóm hiện có hoặc tạo một nhóm mới
+(để xem những gì cần thiết, hãy đọc [Hướng dẫn Bản địa hóa](https://github.com/cncf/glossary/blob/main/LOCALIZATION.md) của chúng tôi).
+Vui lòng đọc hướng dẫn **Cách đóng góp** của ngôn ngữ mục tiêu để nắm được các chi tiết cụ thể về quy trình đóng góp của nhóm đó.
+
+## Kiểm tra chính tả {#spell-check}
+
+Có hai lý do chính khiến kiểm tra chính tả có thể thất bại:
+
+- PR chứa lỗi chính tả.
+- PR chứa các từ chưa được đăng ký trong danh sách từ.
+
+Để thêm từ mới vào danh sách, hãy làm theo các bước sau:
+
+1. Trong PR của bạn, định vị file "wordlist.txt".
+2. Nhấp vào "Edit this file" và thêm các từ còn thiếu theo thứ tự bảng chữ cái.
+3. Thêm thông điệp commit và chọn "Sign off and propose changes".
+
+**Lưu ý**: kiểm tra chính tả không phân biệt chữ hoa chữ thường.
+
+
+**Chúng tôi đã cập nhật hướng dẫn này dựa trên các mẫu từ [The Good Docs Project](https://thegooddocsproject.dev/).**

--- a/content/vi/style-guide/_index.md
+++ b/content/vi/style-guide/_index.md
@@ -1,0 +1,245 @@
+---
+title: Quy tắc Trình bày
+toc_hide: true
+status: Completed
+menu:
+  main:
+    weight: 10
+---
+
+Quy tắc trình bày này sẽ giúp bạn hiểu về đối tượng độc giả của Từ điển, cấu trúc định nghĩa, mức độ chi tiết cần thiết, và cách duy trì phong cách nhất quán.
+
+Từ Điển Cloud Native tuân theo [quy tắc trình bày mặc định](https://github.com/cncf/foundation/blob/master/style-guide.md) của kho lưu trữ CNCF.
+Ngoài ra, nó còn tuân theo các quy tắc sau:
+
+1. Sử dụng ngôn ngữ đơn giản, dễ tiếp cận, tránh thuật ngữ kỹ thuật và từ ngữ thời thượng
+2. [Tránh ngôn ngữ thông tục](https://en.wikipedia.org/wiki/Colloquialism)
+3. [Sử dụng ngôn ngữ nghĩa đen và cụ thể](https://guidetogrammar.org/grammar/composition/abstract.htm)
+4. [Tránh dùng từ viết tắt](https://en.wikipedia.org/wiki/Contraction_(grammar))
+5. [Hạn chế sử dụng câu bị động](https://www.ef.com/ca/english-resources/english-grammar/passive-voice/)
+6. [Cố gắng diễn đạt câu ở dạng khẳng định](https://examples.yourdictionary.com/positive-sentence-examples.html)
+7. [Không sử dụng dấu chấm than ngoài trích dẫn](https://www.grammarly.com/blog/exclamation-mark/)
+8. Không phóng đại
+9. Tránh lặp lại
+10. Ngắn gọn, súc tích
+
+## Đối tượng độc giả
+
+Từ điển được viết cho cả đối tượng kỹ thuật *và* phi kỹ thuật.
+Vui lòng giải thích các định nghĩa bằng từ ngữ đơn giản, và không giả định người đọc có kiến thức kỹ thuật. Chi tiết thêm về điều này được trình bày trong phần [Định nghĩa](#definition) và [Quy tắc Trình bày Ngôn ngữ Ký hiệu](#sign-language-style-guide).
+
+## Định nghĩa tối thiểu khả thi
+
+Chúng tôi hướng tới việc giúp mọi người dễ dàng hiểu các thuật ngữ cloud native.
+Do đó, chúng tôi tập trung vào tính đơn giản.
+Sử dụng ngôn ngữ rõ ràng, đơn giản với các ví dụ mà bất kỳ ai sử dụng công nghệ đều có thể liên hệ được, đồng thời cung cấp một *định nghĩa tối thiểu khả thi*, ít nhất là từ góc độ kỹ thuật.
+Chúng tôi không muốn tiết kiệm ngữ cảnh và ví dụ—xét cho cùng, những điều này giúp người đọc hiểu khái niệm—nhưng nếu một chi tiết kỹ thuật không cần thiết để hiểu nó, chúng tôi sẽ bỏ qua.
+Mục tiêu không phải là làm phức tạp vấn đề. Khi người đọc đã hiểu ý tưởng cơ bản, các tài liệu khác sẽ giúp họ tìm hiểu sâu hơn.
+Phần đó nằm ngoài phạm vi của Từ điển này.
+
+## Mẫu định nghĩa
+
+Mỗi thuật ngữ trong từ điển được lưu trữ trong một file markdown và tuân theo mẫu này:
+
+```md
+---
+title: 
+status: 
+category: 
+---
+
+
+Tóm tắt ngắn gọn về công nghệ hoặc khái niệm.
+
+## Vấn đề nó giải quyết
+
+Một vài dòng về vấn đề mà nó đang giải quyết.
+
+## Cách nó giúp ích
+
+Một vài dòng về cách thức giải quyết vấn đề.
+```
+
+### Tiêu đề
+
+Nhãn **title** sẽ luôn ở đầu bố cục định nghĩa, và giá trị của nó phải ở dạng Title Case.
+
+```md
+---
+title: Mẫu Định nghĩa
+```
+
+### Trạng thái
+
+Nhãn **status** sẽ đến sau nhãn title. Các nhãn này cho biết lượng công sức còn cần thiết để hoàn thành định nghĩa.
+
+Các giá trị hợp lệ là:
+
+- Completed
+- Feedback Appreciated
+- Not Started
+
+Bạn luôn có thể mở một issue cho định nghĩa đã hoàn thành. Khi một định nghĩa đang trong quá trình thay đổi, trạng thái của nó sẽ được chuyển thành *Feedback Appreciated*. Lưu ý rằng chúng ta không nên bản địa hóa các giá trị trạng thái hợp lệ.
+
+```md
+---
+title: Mẫu Định nghĩa
+status: Feedback Appreciated
+```
+
+### Thẻ
+
+Nhãn **tag** theo sau nhãn status.
+Để các thẻ có ý nghĩa và hữu ích cho người dùng, chúng tôi sẽ sử dụng chúng một cách nghiêm ngặt.
+Áp dụng quá nhiều thẻ sẽ chỉ làm loãng ý nghĩa của chúng.
+Một ngoại lệ là thẻ `fundamental`, cho biết thuật ngữ này cần thiết để hiểu các khái niệm cloud native khác; hầu hết các thuật ngữ có thể chỉ có một thẻ.
+
+**Lưu ý**: Vui lòng chỉ giới thiệu thẻ mới nếu được maintainer phê duyệt. Khi thêm thẻ vào một mục, đảm bảo chúng được viết chính xác như danh sách dưới đây (số ít, không lỗi chính tả).
+
+Các thẻ hiện tại là:
+
+- application
+- architecture
+- fundamental
+- infrastructure
+- methodology
+- networking
+- property
+- security
+
+```md
+---
+title: Mẫu Định nghĩa
+status: Feedback Appreciated
+tags: ["tag 1", "tag 2", ""]
+---
+```
+
+### Định nghĩa
+
+#### Hai phần phụ
+
+Các định nghĩa cho các danh mục **công nghệ** và **khái niệm** bao gồm một tóm tắt ngắn gọn và hai phần phụ:
+
+- (tóm tắt ngắn gọn) cung cấp tổng quan ngắn gọn và rõ ràng về nội dung đang được đề cập.
+- **Vấn đề nó giải quyết**: tập trung vào vấn đề, không phải giải pháp (phần đó sẽ được đề cập trong phần tiếp theo).
+  Tránh đề cập đến thuật ngữ đang được định nghĩa. Phần vấn đề tập trung vào *điều gì* dẫn đến việc chúng ta cần thứ đó.
+- **Cách nó giúp ích**: bây giờ, quay lại thuật ngữ. Nó giải quyết vấn đề được mô tả ở trên như thế nào?
+
+Lưu ý rằng các **thuộc tính** không yêu cầu các phần riêng biệt. Một định nghĩa là đủ.
+
+Vui lòng sử dụng **ngắt dòng theo ngữ nghĩa** (mỗi câu một dòng) để dễ dàng cho việc đánh giá.
+
+#### Chất lượng là ưu tiên hàng đầu
+
+Nếu được hợp nhất, định nghĩa của bạn sẽ trở thành định nghĩa chính thức của CNCF cho thuật ngữ đó (cho đến khi có người khác cải thiện nó).
+Việc tạo ra một thuật ngữ đáp ứng các tiêu chuẩn cao của CNCF không thể vội vàng—chất lượng cần thời gian và nỗ lực.
+
+**Nghiên cứu kỹ**: Ngay cả khi bạn tự tin rằng mình hiểu thuật ngữ, hãy xác minh rằng bạn đã hiểu đúng.
+Chúng ta thường sử dụng các thuật ngữ trong tổ chức theo một cách nhất định mà có thể không phản ánh đầy đủ bức tranh tổng thể.
+Khi nghiên cứu, đặc biệt là khi bạn không hoàn toàn quen thuộc với thuật ngữ, hãy sử dụng nhiều nguồn tài liệu.
+Nhiều định nghĩa có thể từ một phía, đặc biệt là nếu được cung cấp bởi một nhà cung cấp.
+Từ điển phải chứa các định nghĩa trung lập với nhà cung cấp và được chấp nhận toàn cầu.
+
+**Không đạo văn**. Các quy tắc tương tự áp dụng cho Từ điển như với bất kỳ ấn phẩm nghiêm túc nào khác.
+Không sao chép và dán công việc của người khác trừ khi bạn đang trích dẫn và ghi nhận công của họ.
+Nếu bạn thích một phần cụ thể của một định nghĩa, hãy diễn đạt lại bằng từ ngữ của riêng bạn.
+
+**Tham khảo các nguồn có thẩm quyền**. Khi có thể, hãy liên kết đến các nguồn có thẩm quyền như tài liệu dự án.
+Lưu ý rằng chúng ta không thể liên kết đến nội dung được phát triển bởi các nhà cung cấp.
+
+#### Giữ cho đơn giản
+
+Từ điển hướng tới việc **giải thích các khái niệm phức tạp bằng từ ngữ đơn giản**—một nhiệm vụ khó khăn đáng ngạc nhiên có thể sẽ phải sửa đổi nhiều lần.
+Luôn ghi nhớ đối tượng độc giả khi soạn thảo định nghĩa của bạn.
+Tránh sử dụng các thuật ngữ ngành và từ ngữ thời thượng—bạn có thể thấy mình quay lại với chúng và có thể cần phải tự rèn luyện để tìm kiếm các thuật ngữ khác.
+
+Khi thích hợp, sử dụng **ví dụ thực tế** giúp người đọc (đặc biệt là những người không có kiến thức kỹ thuật) hiểu rõ hơn *khi nào* và *tại sao* ý tưởng bạn đang giải thích là phù hợp.
+
+Khi được sử dụng trong định nghĩa của bạn, luôn **liên kết đến các thuật ngữ từ điển hiện có** (chỉ lần đề cập đầu tiên nên được siêu liên kết).
+
+**Ví dụ**: xem phần tóm tắt của [định nghĩa service mesh](/service-mesh/).
+Nó liên kết trở lại các định nghĩa của microservices, service, reliability, và observability.
+Ngoài ra, nó sử dụng một ví dụ thực tế so sánh các thách thức mạng trong môi trường microservices (điều mà người không có kiến thức kỹ thuật không thể liên hệ)
+với các vấn đề wifi (điều mà bất kỳ ai sử dụng laptop đều có thể hiểu).
+Khi có thể, hãy cố gắng tạo ra kết nối đó.
+
+#### Bắt đầu với tài liệu Google hoặc Word
+
+Chúng tôi khuyến nghị bắt đầu với tài liệu Google hoặc Word, để nó nghỉ vài ngày, và quay lại xem xét.
+Điều này sẽ giúp bạn phát hiện các cụm từ hoặc cách diễn đạt có thể được viết theo cách đơn giản và dễ tiếp cận hơn.
+Ngoài ra, hãy đảm bảo chạy kiểm tra chính tả trước khi gửi PR.
+
+Để đảm bảo không ai khác gửi PR trong khi làm việc với một thuật ngữ, hãy nhận (claim) một issue (hoặc tạo một issue) và yêu cầu nó được gán cho bạn.
+Thông tin thêm về điều này có trong tài liệu [Cách Đóng góp](/contribute/).
+
+Trước khi bắt đầu, vui lòng đọc một số thuật ngữ đã được xuất bản trong Từ điển
+để có cảm nhận về mức độ chi tiết và độ khó, và khi nào nên sử dụng ví dụ.
+
+## Quy tắc Trình bày Video Ngôn ngữ Ký hiệu {#sign-language-style-guide}
+
+Nếu bạn muốn đóng góp video ngôn ngữ ký hiệu, vui lòng tuân theo các hướng dẫn sau để đảm bảo video rõ ràng, mang tính thông tin và dễ tiếp cận đối với mọi đối tượng (bao gồm cả cộng đồng người không khiếm thính).
+
+### Thiết bị kỹ thuật
+
+Tất cả những gì bạn cần là một camera độ phân giải cao và một giá đỡ. Một điện thoại thông minh hiện đại là đủ.
+
+### Thiết lập Ghi hình
+
+* **Ánh sáng:** Sử dụng ánh sáng phía trước để đảm bảo khuôn mặt và bàn tay của bạn được chiếu sáng tốt.
+
+* **Nền:** Ghi hình trước một nền phẳng, đơn sắc để tránh làm phân tâm khỏi việc ký hiệu. Đảm bảo không có trang trí gây mất tập trung.
+
+* **Quy tắc Trang phục:** Mặc áo đơn sắc (không có họa tiết) tương phản với màu da của bạn.
+
+* **Vị trí Camera:** Đảm bảo rằng từ đầu đến khuỷu tay của bạn hiển thị trên màn hình, và đặt camera ngang tầm mắt. Camera nên vuông góc với nền để nó xuất hiện thẳng, không nghiêng.
+
+* **Không gian Diễn đạt:** Tận dụng không gian tối đa có thể để đảm bảo bạn có đủ không gian thực hiện ký hiệu khi ngồi hoặc đứng.
+
+* **Âm thanh:** Tắt micrô (âm thanh đầu vào) khi có thể để tránh tiếng ồn nền không mong muốn.
+
+### Ký hiệu
+
+* **Rõ ràng và Chính xác:** Ghi lại ký hiệu hai lần từ hướng chính diện, ký hiệu đủ chậm để người không biết ký hiệu có thể nhìn thấy và bắt chước. Việc thể hiện ký hiệu từ bên cạnh là không cần thiết trừ khi nó làm rõ hơn.
+
+* **Biểu cảm Khuôn mặt:** Sử dụng biểu cảm khuôn mặt thoải mái hoặc trung tính. Không khuyến khích việc phát âm miệng hoặc nhăn nhó. Duy trì giao tiếp bằng mắt với camera nếu có thể.
+
+* **Tần suất:** Chỉ cần một ký hiệu cho mỗi video, vì có thể lặp lại khi phát. Không cần thiết phải lặp lại ký hiệu trong video.
+
+* **Thời lượng:** Tổng thời lượng video không nên vượt quá 7 giây.
+
+* **Đánh vần bằng ngón tay:** Sử dụng ngôn ngữ ký hiệu cho từ càng nhiều càng tốt. Đánh vần bằng ngón tay là phương án cuối cùng, thường dành cho các từ viết tắt hoặc từ ngắn.
+
+* **Tư thế:** Duy trì hướng chính diện với mắt nhìn vào camera khi ký hiệu. Không cần thiết phải thể hiện ký hiệu từ hướng bên cạnh. Khi nghỉ, tay nên để xuống với bàn tay thư giãn.
+
+### Mẹo
+
+* **Tiết kiệm dung lượng lưu trữ:** Hãy nhớ rằng video càng ngắn, file càng nhỏ. Nó sẽ tải lên nhanh hơn.
+
+* **Sai sót là tốt:** Giữ việc ghi hình tiếp tục trong khi thực hiện nhiều lần thử. Bạn có nhiều khả năng tìm thấy một đoạn tốt giữa các lần thử, và bạn có thể cắt bỏ các phần không mong muốn. Điều này hiệu quả hơn việc thực hiện nhiều bản ghi với một lần thử ký hiệu trong mỗi bản.
+
+* **Ví dụ Video:** Vui lòng tham khảo danh sách phát [CNCF Glossary: Cloud Native Signs](https://www.youtube.com/playlist?list=PLj6h78yzYM2PDlYnmfpRfKgcgBMb34kb5) để xem ví dụ.
+
+### Hậu kỳ
+
+* **Chỉnh sửa:** Nếu cần thiết, cắt bớt phần đầu và cuối của video.
+
+* **Nhãn:** Tối thiểu, tên file của video phải chứa thuật ngữ từ điển của ký hiệu trước khi tải lên. Ví dụ, kubernetes.mp4.
+
+* **Âm thanh:** Loại bỏ hoàn toàn track âm thanh, nếu có thể.
+
+* **Tải lên:** Chia sẻ video trên kênh #glossary-sign-language Slack và yêu cầu phản hồi. Nếu được phê duyệt, các trưởng nhóm Từ điển Ngôn ngữ Ký hiệu sẽ giúp bạn tải video lên Danh sách phát CNCF. Vui lòng không tải video lên YouTube cá nhân của bạn vì YouTube có thể xóa các video trùng lặp từ tất cả các tài khoản sử dụng cùng video (để ngăn chặn lạm dụng kiếm tiền) khi CNCF sử dụng YouTube để tải lên video cuối cùng.
+
+* **Tải video lên danh sách phát CNCF:** Chia sẻ video trên kênh #glossary-sign-language Slack và yêu cầu phản hồi. Nếu được phê duyệt, các trưởng nhóm Từ điển Ngôn ngữ Ký hiệu sẽ giúp bạn tải video lên Danh sách phát CNCF.
+
+## Quy trình đánh giá: Những điều cần biết
+
+Xin lưu ý rằng hiện tại chúng tôi chỉ có một số ít maintainer làm việc này trong thời gian rảnh của họ.
+Đôi khi, chúng tôi có thể đánh giá các thuật ngữ nhanh chóng; vào những dịp khác, có thể mất một thời gian—chúng tôi đánh giá cao sự kiên nhẫn của bạn.
+Nếu bạn có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi trong kênh Slack #glossary
+(để biết nơi và cách tìm nó, vui lòng tham khảo tài liệu [Cách Đóng góp](/contribute/) của chúng tôi).
+
+Mục tiêu của chúng tôi là để Từ điển trở thành nguồn tài nguyên tốt nhất có thể.
+Sau khi bạn gửi PR, chúng tôi có thể yêu cầu một hoặc nhiều lần sửa đổi.
+Đừng nản lòng—điều đó xảy ra với nhiều PR.
+Những trao đổi qua lại này và sự hợp tác của chúng ta sẽ đảm bảo rằng đóng góp của bạn sẽ trở thành một định nghĩa hữu ích được đọc và tham khảo bởi độc giả trên toàn cầu.

--- a/content/vi/style-guide/_index.md
+++ b/content/vi/style-guide/_index.md
@@ -115,7 +115,7 @@ tags: ["tag 1", "tag 2", ""]
 ---
 ```
 
-### Định nghĩa
+### Định nghĩa {#definition}
 
 #### Hai phần phụ
 

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -1,0 +1,96 @@
+# UI strings. Buttons and similar.
+
+[ui_pager_prev]
+other = "Trước"
+
+[ui_pager_next]
+other = "Tiếp"
+
+[ui_read_more]
+other = "Xem thêm"
+
+[ui_search]
+other = "Tìm kiếm..."
+
+# Used in sentences such as "Posted in News"
+[ui_in]
+other = "trong"
+
+# Phrases for tags
+[ui_see_all_tags]
+other = "Xem tất cả thẻ"
+[ui_tag]
+other = "Thẻ"
+[ui_tags]
+other = "Các thẻ"
+[ui_search_by_tags]
+other = "Duyệt theo thẻ"
+[ui_tags_intro]
+other = "Chúng tôi đã phân loại các thuật ngữ. Sử dụng bộ lọc để duyệt các thuật ngữ theo thẻ."
+[ui_or_search_by_tags]
+other = "...hoặc duyệt theo thẻ"
+[ui_select_all]
+other = "Chọn tất cả"
+[ui_deselect_all]
+other = "Bỏ chọn tất cả"
+
+# Footer text
+[footer_all_rights_reserved]
+other = "Bảo lưu mọi quyền"
+
+[footer_privacy_policy]
+other = "Chính sách bảo mật"
+
+[footer_hub_button_text]
+other = "Tất cả trang CNCF"
+
+# Post (blog, articles etc.)
+[post_byline_by]
+other = "Bởi"
+[post_created]
+other = "Đã tạo"
+[post_last_mod]
+other = "Cập nhật lần cuối"
+[post_edit_this]
+other = "Chỉnh sửa trang này"
+[post_create_child_page]
+other = "Tạo trang con"
+[post_create_issue]
+other = "Báo cáo vấn đề"
+[post_create_project_issue]
+other = "Tạo vấn đề dự án"
+[post_posts_in]
+other = "Bài viết trong"
+[post_reading_time]
+other = "phút đọc"
+
+# Print support
+[print_printable_section]
+other = "Đây là chế độ xem có thể in nhiều trang của phần này."
+[print_click_to_print]
+other = "Nhấn vào đây để in"
+[print_show_regular]
+other = "Quay lại chế độ xem thường"
+[print_entire_section]
+other = "In toàn bộ phần"
+
+# Feedback section
+[feedback_title]
+other = "Phản hồi"
+[feedback_question]
+other = "Trang này có hữu ích không?"
+[feedback_answer_yes]
+other = "Có"
+[feedback_answer_no]
+other = "Không"
+
+# Sign language section
+[sign_language_header]
+other = "Bằng ngôn ngữ ký hiệu"
+[sign_language_info]
+other = """
+**Lưu ý**:
+Mặc dù mỗi quốc gia có ngôn ngữ ký hiệu riêng,
+[Nhóm Làm việc Người Khiếm thính/Lãng tai](https://contribute.cncf.io/accessibility/deaf-and-hard-of-hearing/)
+của chúng tôi hướng tới việc chuẩn hóa các ký hiệu cho các thuật ngữ cloud-native mới để sử dụng toàn cầu.
+"""


### PR DESCRIPTION
This PR is to initiate Vietnamese localization based on

- Issue to #3458 
- https://github.com/cncf/glossary/blob/main/LOCALIZATION.md guide

Base and target branch of this PR is dev-vi which is development branch for Vietnamese localization.

This PR includes

- `[languages.vi]` section in `config.toml`
- content/**vi**/ directory
- i18n/vi.toml
- Some translated documents
   - Main page
      - content/vi/_index.md
   - Others
      - contribute: content/vi/contribute/_index.md (partially localized)
      - style-guide: content/vi/style-guide/_index.md (partially localized)
     
Since Vietnamese localization team owns content/vi/* only,
this PR will require approvals from upstream owners (maintainers).