### PR TITLE
Replace TR l10n approvers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -223,13 +223,13 @@ collaborators:
   - username: aliok
     permission: push
 
-  - username: symys
+  - username: canogluonur
     permission: push
 
-  - username: rwxdash
+  - username: mertssmnoglu
     permission: push
 
-  - username: eminalemdar
+  - username: alianait
     permission: push
 
   # l10n ru approvers
@@ -527,9 +527,9 @@ branches:
         # tr approvers
         users:
          - aliok
-         - symys
-         - rwxdash
-         - eminalemdar
+         - canogluonur
+         - mertssmnoglu
+         - alianait
         teams: []
       enforce_admins: null
       required_linear_history: null

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,8 +63,8 @@
 /i18n/ru.toml @shurup @kirkonru @tym83
 
 # Approvers for Turkish contents
-/content/tr/ @aliok @symys @rwxdash @eminalemdar
-/i18n/tr.toml @aliok @symys @rwxdash @eminalemdar
+/content/tr/ @aliok @canogluonur @mertssmnoglu @alianait
+/i18n/tr.toml @aliok @canogluonur @mertssmnoglu @alianait
 
 # Approvers for Urdu contents
 /content/ur/ @Saim-Safdar @waleed318


### PR DESCRIPTION
### Describe your changes
We are restarting our efforts to localize CNCF Glossary to Turkish.

We would like to thank @symys @rwxdash @eminalemdar for their work and replace them with @canogluonur @mertssmnoglu @alianait as approvers.

### Related issue number or link (ex: `resolves #issue-number`)

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
