### PR TITLE
feat: add grpc to glossary

### DIFF
--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -12,7 +12,7 @@ It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definiti
 
 gRPC addresses common [distributed-systems](/distributed-systems/) challenges such as inefficient text-based payloads, inconsistent service contracts across languages, limited streaming support, and high-latency multiplexing over HTTP/1.1. 
 It also reduces boilerplate by generating code from a single source of truth.
-In modern [microservices architectures](./microservices-architecture.md), these issues become critical as services frequently communicate with each other. 
+In modern [microservices architectures](/microservices-architecture/), these issues become critical as services frequently communicate with each other. 
 gRPC offers a consistent, high-performance way for services written in different languages to interoperate, without relying on verbose REST/JSON payloads or inconsistent APIs.
 
 

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -5,7 +5,7 @@ category: concept
 tags: [methodology, network]
 ---
 
-gRPC is a modern, open-source, high-performance Remote Procedure Call (RPC) framework that can run in any environment. 
+[gRPC](https://grpc.io/) is a modern, open-source, high-performance Remote Procedure Call (RPC) framework that can run in any environment. 
 It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definition and serialization, and provides features such as bi-directional streaming, flow control, header compression, and multiplexing.
 
 ## Problem it solves?

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -2,7 +2,7 @@
 title: gRPC
 status: Completed
 category: concept
-tags: ["methodology", "network", ""]
+tags: [methodology, network]
 ---
 
 gRPC is a modern, open-source, high-performance Remote Procedure Call (RPC) framework that can run in any environment. 

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -22,6 +22,6 @@ Protocol Buffers provide compact and efficient binary serialization, which reduc
 
 For **microservices**, gRPC simplifies service-to-service communication and scales well in polyglot environments. 
 Its **bi-directional streaming** makes it suitable not just for request/response patterns but also for real-time event-driven use cases such as log aggregation, IoT telemetry, or live data pipelines. 
-While it is not a replacement for [event streaming](./event-streaming.md) platforms like Kafka, gRPC often complements them by providing fast, low-latency RPC communication at the service layer.  
+While it is not a replacement for [event streaming](/event-streaming/) platforms like Kafka, gRPC often complements them by providing fast, low-latency RPC communication at the service layer.  
 
 Built-in primitives such as deadlines, metadata, and interceptors support robust, production-grade communication across heterogeneous environments.

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -10,7 +10,7 @@ It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definiti
 
 ## Problem it solves?
 
-gRPC addresses common [distributed-systems](./distributed-systems.md) challenges such as inefficient text-based payloads, inconsistent service contracts across languages, limited streaming support, and high-latency multiplexing over HTTP/1.1. 
+gRPC addresses common [distributed-systems](/distributed-systems/) challenges such as inefficient text-based payloads, inconsistent service contracts across languages, limited streaming support, and high-latency multiplexing over HTTP/1.1. 
 It also reduces boilerplate by generating code from a single source of truth.
 In modern [microservices architectures](./microservices-architecture.md), these issues become critical as services frequently communicate with each other. 
 gRPC offers a consistent, high-performance way for services written in different languages to interoperate, without relying on verbose REST/JSON payloads or inconsistent APIs.

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -10,7 +10,7 @@ Think of it as a highly optimized way for one program to request and receive dat
 Unlike traditional approaches like REST APIs that use text-based messages, gRPC uses a compact binary format, making communication faster and more efficient. 
 It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definition and serialization, and provides features such as bi-directional streaming, flow control, header compression, and multiplexing.
 
-## Problem it solves
+## Problem it addresses
 
 Imagine two applications that need to communicate frequently—like a mobile app talking to a server, or different backend services coordinating with each other. 
 Traditional text-based approaches (like REST with JSON) work but can be slow and wasteful because text is verbose and requires extra processing. 

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -1,0 +1,27 @@
+---
+title: gRPC
+status: Completed
+category: concept
+tags: ["methodology", "network", ""]
+---
+
+gRPC is a modern, open-source, high-performance Remote Procedure Call (RPC) framework that can run in any environment. 
+It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definition and serialization, and provides features such as bi-directional streaming, flow control, header compression, and multiplexing.
+
+## Problem it solves?
+
+gRPC addresses common [distributed-systems](./distributed-systems.md) challenges such as inefficient text-based payloads, inconsistent service contracts across languages, limited streaming support, and high-latency multiplexing over HTTP/1.1. 
+It also reduces boilerplate by generating code from a single source of truth.
+In modern [microservices architectures](./microservices-architecture.md), these issues become critical as services frequently communicate with each other. 
+gRPC offers a consistent, high-performance way for services written in different languages to interoperate, without relying on verbose REST/JSON payloads or inconsistent APIs.
+
+
+## How it helps
+
+Protocol Buffers provide compact and efficient binary serialization, which reduces payload size and CPU usage. Leveraging HTTP/2 enables multiplexed requests, lower latency, and native support for client, server, and bidirectional streaming. Generated client and server code enforce a single source of truth for service contracts, reducing integration errors and development overhead.  
+
+For **microservices**, gRPC simplifies service-to-service communication and scales well in polyglot environments. 
+Its **bi-directional streaming** makes it suitable not just for request/response patterns but also for real-time event-driven use cases such as log aggregation, IoT telemetry, or live data pipelines. 
+While it is not a replacement for [event streaming](./event-streaming.md) platforms like Kafka, gRPC often complements them by providing fast, low-latency RPC communication at the service layer.  
+
+Built-in primitives such as deadlines, metadata, and interceptors support robust, production-grade communication across heterogeneous environments.

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -5,23 +5,45 @@ category: concept
 tags: [methodology, network]
 ---
 
-[gRPC](https://grpc.io/) is a modern, open-source, high-performance Remote Procedure Call (RPC) framework that can run in any environment. 
+[gRPC](https://grpc.io/) is a modern, open-source Remote Procedure Call (RPC) framework that allows different applications to talk to each other efficiently. 
+Think of it as a highly optimized way for one program to request and receive data from another program over a network. 
+Unlike traditional approaches like REST APIs that use text-based messages, gRPC uses a compact binary format, making communication faster and more efficient. 
 It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definition and serialization, and provides features such as bi-directional streaming, flow control, header compression, and multiplexing.
 
-## Problem it solves?
+## Problem it solves
 
-gRPC addresses common [distributed-systems](/distributed-systems/) challenges such as inefficient text-based payloads, inconsistent service contracts across languages, limited streaming support, and high-latency multiplexing over HTTP/1.1. 
-It also reduces boilerplate by generating code from a single source of truth.
-In modern [microservices architectures](/microservices-architecture/), these issues become critical as services frequently communicate with each other. 
-gRPC offers a consistent, high-performance way for services written in different languages to interoperate, without relying on verbose REST/JSON payloads or inconsistent APIs.
+Imagine two applications that need to communicate frequently—like a mobile app talking to a server, or different backend services coordinating with each other. 
+Traditional text-based approaches (like REST with JSON) work but can be slow and wasteful because text is verbose and requires extra processing. 
+gRPC solves this by sending data in a compact binary format, which is faster to transmit and faster to process.
+
+In [microservices architectures](/microservices-architecture/), services written in different programming languages need a consistent way to communicate. 
+gRPC provides this by defining interfaces once and automatically generating code for any language, reducing misunderstandings and errors between teams.
+
+It also addresses common [distributed-systems](/distributed-systems/) challenges like inefficient payloads, inconsistent service contracts across languages, limited streaming support, and high-latency communication.
+
+## gRPC vs. Alternatives
+
+| Aspect | gRPC | REST/JSON | SOAP/XML |
+|--------|------|----------|----------|
+| **Data Format** | Binary (compact) | Text (verbose) | Text (very verbose) |
+| **Speed** | Very fast | Slower | Slower |
+| **Streaming** | Full bi-directional | Limited | Limited |
+| **Learning Curve** | Moderate | Easy | Difficult |
+| **Browser Support** | Limited* | Excellent | Good |
+| **Best For** | Service-to-service, real-time | General APIs, public APIs | Enterprise systems |
+
+*gRPC traditionally requires HTTP/2, which browser JavaScript doesn't fully support, though gRPC-web addresses this.
 
 
 ## How it helps
 
-Protocol Buffers provide compact and efficient binary serialization, which reduces payload size and CPU usage. Leveraging HTTP/2 enables multiplexed requests, lower latency, and native support for client, server, and bidirectional streaming. Generated client and server code enforce a single source of truth for service contracts, reducing integration errors and development overhead.  
+**Fast and Efficient Communication**: Protocol Buffers compress data into a compact binary format, which reduces the amount of data sent over the network and the processing power needed to read it.
 
-For **microservices**, gRPC simplifies service-to-service communication and scales well in polyglot environments. 
-Its **bi-directional streaming** makes it suitable not just for request/response patterns but also for real-time event-driven use cases such as log aggregation, IoT telemetry, or live data pipelines. 
-While it is not a replacement for [event streaming](/event-streaming/) platforms like Kafka, gRPC often complements them by providing fast, low-latency RPC communication at the service layer.  
+**Real-time Streaming**: gRPC supports bi-directional streaming, meaning a client can send data while a server sends data back simultaneously. This is useful for live data pipelines, IoT sensors reporting continuously, or real-time notifications.
 
-Built-in primitives such as deadlines, metadata, and interceptors support robust, production-grade communication across heterogeneous environments.
+**Multiple Languages Working Together**: Code is auto-generated from a single service definition, so whether you're using Python, Java, Go, or Node.js, all services speak the same language. This reduces integration errors and development time.
+
+**Simple Example**: Consider a ride-sharing app where the mobile app needs to constantly track driver locations and receive real-time updates. With gRPC's bi-directional streaming, the driver app can continuously send location updates while the server pushes route changes and passenger information back—all efficiently and with minimal latency.
+
+While gRPC is great for service-to-service communication, it's not meant to replace [event streaming](/event-streaming/) platforms like Kafka for high-volume event processing. Instead, gRPC often complements them by handling fast, direct communication between services.
+

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -32,7 +32,7 @@ It also addresses common [distributed-systems](/distributed-systems/) challenges
 | **Browser Support** | Limited* | Excellent | Good |
 | **Best For** | Service-to-service, real-time | General APIs, public APIs | Enterprise systems |
 
-*gRPC traditionally requires HTTP/2, which browser JavaScript doesn't fully support, though gRPC-web addresses this.
+gRPC traditionally requires HTTP/2, which browser JavaScript doesn't fully support, though gRPC-web addresses this.
 
 
 ## How it helps

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -5,19 +5,19 @@ category: concept
 tags: [methodology, network]
 ---
 
-[gRPC](https://grpc.io/) is a modern, open-source Remote Procedure Call (RPC) framework that allows different applications to talk to each other efficiently. 
-Think of it as a highly optimized way for one program to request and receive data from another program over a network. 
-Unlike traditional approaches like REST APIs that use text-based messages, gRPC uses a compact binary format, making communication faster and more efficient. 
+[gRPC](https://grpc.io/) is a modern, open-source Remote Procedure Call (RPC) framework that allows different applications to talk to each other efficiently.
+Think of it as a highly optimized way for one program to request and receive data from another program over a network.
+Unlike traditional approaches like REST APIs that use text-based messages, gRPC uses a compact binary format, making communication faster and more efficient.
 It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definition and serialization, and provides features such as bi-directional streaming, flow control, header compression, and multiplexing.
 
 ## Problem it addresses
 
-Imagine two applications that need to communicate frequently—like a mobile app talking to a server, or different backend services coordinating with each other. 
-Traditional text-based approaches (like REST with JSON) work but can be slow and wasteful because text is verbose and requires extra processing. 
-gRPC solves this by sending data in a compact binary format, which is faster to transmit and faster to process.
+Imagine two applications that need to communicate frequently—like a mobile app talking to a server, or different backend services coordinating with each other.
+Traditional text-based approaches (like REST with JSON) work but can be slow and wasteful because text is verbose and requires extra processing.
+The gRPC solves this by sending data in a compact binary format, which is faster to transmit and faster to process.
 
-In [microservices architectures](/microservices-architecture/), services written in different programming languages need a consistent way to communicate. 
-gRPC provides this by defining interfaces once and automatically generating code for any language, reducing misunderstandings and errors between teams.
+In [microservices architectures](/microservices-architecture/), services written in different programming languages need a consistent way to communicate.
+A contract-first communication model provides this by defining interfaces once and automatically generating code for any language, reducing misunderstandings and errors between teams.
 
 It also addresses common [distributed-systems](/distributed-systems/) challenges like inefficient payloads, inconsistent service contracts across languages, limited streaming support, and high-latency communication.
 
@@ -39,11 +39,14 @@ gRPC traditionally requires HTTP/2, which browser JavaScript doesn't fully suppo
 
 **Fast and Efficient Communication**: Protocol Buffers compress data into a compact binary format, which reduces the amount of data sent over the network and the processing power needed to read it.
 
-**Real-time Streaming**: gRPC supports bi-directional streaming, meaning a client can send data while a server sends data back simultaneously. This is useful for live data pipelines, IoT sensors reporting continuously, or real-time notifications.
+**Real-time Streaming**: gRPC supports bi-directional streaming, meaning a client can send data while a server sends data back simultaneously.
+This is useful for live data pipelines, IoT sensors reporting continuously, or real-time notifications.
 
-**Multiple Languages Working Together**: Code is auto-generated from a single service definition, so whether you're using Python, Java, Go, or Node.js, all services speak the same language. This reduces integration errors and development time.
+**Multiple Languages Working Together**: Code is auto-generated from a single service definition, so whether you're using Python, Java, Go, or Node.js, all services speak the same language.
+This reduces integration errors and development time.
 
-**Simple Example**: Consider a ride-sharing app where the mobile app needs to constantly track driver locations and receive real-time updates. With gRPC's bi-directional streaming, the driver app can continuously send location updates while the server pushes route changes and passenger information back—all efficiently and with minimal latency.
+**Simple Example**: Consider a ride-sharing app where the mobile app needs to constantly track driver locations and receive real-time updates.
+With gRPC's bi-directional streaming, the driver app can continuously send location updates while the server pushes route changes and passenger information back—all efficiently and with minimal latency.
 
-While gRPC is great for service-to-service communication, it's not meant to replace [event streaming](/event-streaming/) platforms like Kafka for high-volume event processing. Instead, gRPC often complements them by handling fast, direct communication between services.
-
+While gRPC is great for service-to-service communication, it's not meant to replace [event streaming](/event-streaming/) platforms like Kafka for high-volume event processing.
+Instead, gRPC often complements them by handling fast, direct communication between services.

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -5,7 +5,7 @@ category: technology
 tags: ["networking", ""]
 ---
 
-Google Remote Procedure Calls or [gRPC](https://grpc.io/) is a way for different programs to talk to each other over a network.
+[gRPC](https://grpc.io/) is a way for different programs to talk to each other over a network.
 Think of it like a phone system where one program can call another and request information or ask it to do something.
 Unlike older methods that send messages as text (which is slow and uses more data), 
 gRPC sends messages in a compact format that computers can read faster.

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -32,4 +32,4 @@ gRPC allows programs to send and receive information at the same time,
 like having a conversation instead of exchanging letters.
 For example, in a ride-sharing app, 
 a driver's phone can continuously send location updates 
-while receiving new passenger requests and route changes at the same time.
+while receiving new passenger requests and route changes.

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -5,7 +5,7 @@ category: technology
 tags: ["networking", ""]
 ---
 
-[gRPC](https://grpc.io/) is a way for different programs to talk to each other over a network.
+Google Remote Procedure Calls or [gRPC](https://grpc.io/) is a way for different programs to talk to each other over a network.
 Think of it like a phone system where one program can call another and request information or ask it to do something.
 Unlike older methods that send messages as text (which is slow and uses more data), 
 gRPC sends messages in a compact format that computers can read faster.
@@ -26,7 +26,7 @@ Without clear rules for how they should communicate, errors and misunderstanding
 gRPC solves this by using a compact format to send information, 
 which is faster to transmit and process.
 It also lets you define once how programs should talk to each other, 
-and then automatically creates the necessary code for any programming language you are using.
+and then for various programming languages the protocol supports automatically creates the necessary code.
 
 gRPC allows programs to send and receive information at the same time, 
 like having a conversation instead of exchanging letters.

--- a/content/en/grpc.md
+++ b/content/en/grpc.md
@@ -1,52 +1,35 @@
 ---
 title: gRPC
 status: Completed
-category: concept
-tags: [methodology, network]
+category: technology
+tags: ["networking", ""]
 ---
 
-[gRPC](https://grpc.io/) is a modern, open-source Remote Procedure Call (RPC) framework that allows different applications to talk to each other efficiently.
-Think of it as a highly optimized way for one program to request and receive data from another program over a network.
-Unlike traditional approaches like REST APIs that use text-based messages, gRPC uses a compact binary format, making communication faster and more efficient.
-It uses HTTP/2 for transport, Protocol Buffers (protobuf) for interface definition and serialization, and provides features such as bi-directional streaming, flow control, header compression, and multiplexing.
+[gRPC](https://grpc.io/) is a way for different programs to talk to each other over a network.
+Think of it like a phone system where one program can call another and request information or ask it to do something.
+Unlike older methods that send messages as text (which is slow and uses more data), 
+gRPC sends messages in a compact format that computers can read faster.
 
 ## Problem it addresses
 
-Imagine two applications that need to communicate frequently—like a mobile app talking to a server, or different backend services coordinating with each other.
-Traditional text-based approaches (like REST with JSON) work but can be slow and wasteful because text is verbose and requires extra processing.
-The gRPC solves this by sending data in a compact binary format, which is faster to transmit and faster to process.
+When programs need to share information frequently, sending text-based messages back and forth can be slow.
+Imagine sending a detailed letter every time you need to ask a simple question—it takes time to write, send, and read.
+This becomes a bigger problem when you have many programs working together, 
+each needing quick answers from the others.
 
-In [microservices architectures](/microservices-architecture/), services written in different programming languages need a consistent way to communicate.
-A contract-first communication model provides this by defining interfaces once and automatically generating code for any language, reducing misunderstandings and errors between teams.
-
-It also addresses common [distributed-systems](/distributed-systems/) challenges like inefficient payloads, inconsistent service contracts across languages, limited streaming support, and high-latency communication.
-
-## gRPC vs. Alternatives
-
-| Aspect | gRPC | REST/JSON | SOAP/XML |
-|--------|------|----------|----------|
-| **Data Format** | Binary (compact) | Text (verbose) | Text (very verbose) |
-| **Speed** | Very fast | Slower | Slower |
-| **Streaming** | Full bi-directional | Limited | Limited |
-| **Learning Curve** | Moderate | Easy | Difficult |
-| **Browser Support** | Limited* | Excellent | Good |
-| **Best For** | Service-to-service, real-time | General APIs, public APIs | Enterprise systems |
-
-gRPC traditionally requires HTTP/2, which browser JavaScript doesn't fully support, though gRPC-web addresses this.
-
+Additionally, when different programs are built using different programming languages, 
+they need a common way to understand each other.
+Without clear rules for how they should communicate, errors and misunderstandings can occur.
 
 ## How it helps
 
-**Fast and Efficient Communication**: Protocol Buffers compress data into a compact binary format, which reduces the amount of data sent over the network and the processing power needed to read it.
+gRPC solves this by using a compact format to send information, 
+which is faster to transmit and process.
+It also lets you define once how programs should talk to each other, 
+and then automatically creates the necessary code for any programming language you are using.
 
-**Real-time Streaming**: gRPC supports bi-directional streaming, meaning a client can send data while a server sends data back simultaneously.
-This is useful for live data pipelines, IoT sensors reporting continuously, or real-time notifications.
-
-**Multiple Languages Working Together**: Code is auto-generated from a single service definition, so whether you're using Python, Java, Go, or Node.js, all services speak the same language.
-This reduces integration errors and development time.
-
-**Simple Example**: Consider a ride-sharing app where the mobile app needs to constantly track driver locations and receive real-time updates.
-With gRPC's bi-directional streaming, the driver app can continuously send location updates while the server pushes route changes and passenger information back—all efficiently and with minimal latency.
-
-While gRPC is great for service-to-service communication, it's not meant to replace [event streaming](/event-streaming/) platforms like Kafka for high-volume event processing.
-Instead, gRPC often complements them by handling fast, direct communication between services.
+gRPC allows programs to send and receive information at the same time, 
+like having a conversation instead of exchanging letters.
+For example, in a ride-sharing app, 
+a driver's phone can continuously send location updates 
+while receiving new passenger requests and route changes at the same time.


### PR DESCRIPTION
### Describe your changes
This pull request adds a new conceptual documentation page for gRPC, covering its purpose, benefits, and use cases in modern distributed systems and microservices architectures.
* Added `content/en/grpc.md` to provide an overview of gRPC, including its architecture (HTTP/2, Protocol Buffers), the problems it solves in distributed systems, and its advantages for microservices, streaming, and interoperability.

### Related issue number or link (ex: `resolves #issue-number`)
resolves #1038 

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`. 