### PR TITLE
[tr] fix(style): Migrate to 2 subheadings style from 3 subheadings

### DIFF
--- a/content/tr/agile-software-development.md
+++ b/content/tr/agile-software-development.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["yöntem", "", ""]
 ---
 
-## Nedir
-
 Çevik yazılım geliştirme, tekrarlayan geliştirme döngülerini ve kendi kendini organize eden ekipleri vurgulayan bir dizi uygulamadır. 
 Değerin yalnızca projenin sonunda üretildiği şelale tarzı projelerin aksine, çevik yazılım geliştirme, 
 değerin sürekli ve kademeli olarak sunulmasına ve sürecin kendisinin evrimsel olarak gelişimine odaklanır.

--- a/content/tr/api-gateway.md
+++ b/content/tr/api-gateway.md
@@ -5,8 +5,6 @@ category: Teknoloji
 tags: ["ağ", "", ""]
 ---
 
-## Nedir
-
 [API](../application-programming-interface/) geçidi, benzersiz uygulama API’lerini bir araya toplayarak hepsinin tek bir yerde kullanılabilir olmasını sağlayan bir araçtır. Organizasyonların kimlik doğrulama, yetkilendirme ve istek sayısını sınırlandırma gibi temel işlevlerin merkezi bir konumdan yönetilmesini sağlar. Bir API geçidi, API tüketicilerine yönelik ortak bir arayüz işlevi görür. 
 
 ## Hangi Sorunları Çözer

--- a/content/tr/application-programming-interface.md
+++ b/content/tr/application-programming-interface.md
@@ -6,8 +6,6 @@ category: Teknoloji
 tags: ["mimari", "temel kavram", ""]
 ---
 
-## Nedir
-
 API, bilgisayar programlarının birbirleriyle etkileşime girmesinin bir yoludur. İnsanların bir web sitesiyle web sayfası aracılığıyla etkileşime girmesi gibi bilgisayar programları API aracılığıyla birbirleriyle etkileşime girer. İnsan etkileşimlerinin aksine, API’lerin kendilerinden ne istenip ne istenmeyeceği konusunda sınırlamaları vardır. Bu sınırlamalar, programlar arasındaki iletişimin istikrarlı ve işlevsel olmasına yardımcı olur.
 
 ## Hangi Sorunları Çözer

--- a/content/tr/blue-green-deployment.md
+++ b/content/tr/blue-green-deployment.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["yöntem", "uygulama", ""]
 ---
 
-## Nedir
-
 Blue green deployment, çalışan bilgisayar sistemlerini minimum sistem kesintisiyle güncellemeye yönelik bir stratejidir. Operatör, “blue” ve “green” olarak adlandırılan iki ortamın devamlılığını sağlar. 
 Biri canlı trafiğe hizmet ederken (tüm kullanıcıların o an kullandığı sürüm), diğeri güncellenir. 
 Aktif olmayan (green) ortamda testler tamamlandıktan sonra, canlı trafiğe geçilir (genellikle bir yük dengeleyici kullanarak). 

--- a/content/tr/canary-deployment.md
+++ b/content/tr/canary-deployment.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["yöntem", "uygulama", ""]
 ---
 
-## Nedir
-
 Canary deployment, biri canlı trafiğe sahip orijinal kodu diğeri ise canlı trafik olmadan güncellenmiş kodu içeren iki ortamla başlayan bir dağıtım stratejisidir. 
 Trafik, uygulamanın orijinal sürümünden güncellenmiş sürümüne kademeli olarak taşınır. 
 Canlı trafiğin %1’ini taşıyarak başlanabilir, sonrasında %10, %25 gibi kademeli artışlarla tüm trafik güncellenmiş sürümde çalışana kadar böyle devam edilebilir. 

--- a/content/tr/client-server-architecture.md
+++ b/content/tr/client-server-architecture.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["mimari", "temel kavram", ""]
 ---
 
-## Nedir
-
 İstemci-sunucu mimarisinde, bir uygulamayı oluşturan mantık (veya kod) iki veya daha fazla bileşen arasında bölünür. 
 Bunlar, işin yapılmasını isteyen bir istemci (örn. web tarayıcınızda çalışan Gmail web uygulaması) ve bu isteği karşılayan bir veya daha fazla sunucudur (örn. Google’ın buluttaki bilgisayarlarında çalışan “e-posta gönder” servisi). 
 Bu örnekte, yazdığınız e-postalar istemci (web tarayıcınızda çalışan uygulaması) tarafından bir sunucuya (Gmail’in giden e-postalarınızı alıcılarına ileten bilgisayarları) gönderilir.

--- a/content/tr/cloud-computing.md
+++ b/content/tr/cloud-computing.md
@@ -5,8 +5,6 @@ category: Kavram
 tags: ["altyapı", "temel kavram", ""]
 ---
 
-## Nedir
-
 Bulut bilişim, internet üzerinden isteğe bağlı olarak CPU, ağ ve disk kapasiteleri gibi bilişim kaynaklarının sunulduğu, kullanıcıların uzaktaki fiziksel bir konumda bilgi işlem gücüne erişebildiği ve kullanabildiği bir hizmettir.
 Genellikle, bulut altyapısının bir organizasyona ayrılmış olup olmadığına veya genele açık hizmetlerde paylaşılıp paylaşılmadığına bağlı olarak, özel veya genel bulut şeklinde bir ayrım yapılır.
 

--- a/content/tr/cloud-native-tech.md
+++ b/content/tr/cloud-native-tech.md
@@ -5,8 +5,6 @@ category: Kavram
 tags: ["temel kavram", "", ""]
 ---
 
-## Nedir
-
 Cloud native yığını olarak da adlandırılan cloud native teknolojileri, [cloud native uygulamaları](/tr/cloud-native-apps/) oluşturmak için kullanılan teknolojilerdir.
 Bu teknolojiler kuruluşlar için genel, özel ve hibrit bulut ortamları gibi modern ve dinamik ortamlarda ölçeklenebilir uygulamalar oluşturmaya ve çalıştırmaya olanak tanırken [bulut bilişimin](/tr/cloud-computing/) yararlarını en üst düzeye çıkarırlar.
 Bulut bilişimin yeteneklerinden yararlanmak için sıfırdan tasarlanmışlardır ve konteynerler, servis ağları, mikro servisler ve sabit altyapı bu yaklaşımın örnekleridir.

--- a/content/tr/cluster.md
+++ b/content/tr/cluster.md
@@ -5,8 +5,6 @@ category: Concept
 tags: ["altyapı", "temel kavram", ""]
 ---
 
-## Nedir
-
 Küme, ortak bir amaç doğrultusunda birlikte çalışan bir grup bilgisayar ve uygulamadır. Cloud native bilişimi bağlamında "küme" kavramı çoğunlukla Kubernetes için kullanılır. [Kubernetes](/tr/kubernetes/) kümesi, genellikle farklı makinelerde olacak şekilde, kendi [konteynerlerini](/tr/containerization/) kullanarak çalışan bir dizi servisten (veya iş yükünden) oluşur. Bir ağ üzerinden bağlanan tüm bu konteynerli servisler bir kümeyi temsil eder.
 
 

--- a/content/tr/container-orchestration.md
+++ b/content/tr/container-orchestration.md
@@ -4,8 +4,6 @@ status: Completed
 category: Concept
 ---
 
-## Nedir
-
 [Konteyner](/container/) orkestrasyonu, dinamik ortamlarda konteynerleştirilmiş uygulamaların yaşam döngüsünün yönetilmesi ve otomasyonunu ifade eder.
 Bu genellikle bir konteyner orkestratörü aracılığıyla gerçekleştirilir (çoğu durumda [Kubernetes](/tr/kubernetes)) ve bu da yük çalıştırmayı, (otomatik) ölçeklendirmeyi, otomatik iyileştirmeyi ve takip etmeyi olanaklı kılar.
 Orkestrasyon bir metafordur: orkestrasyon aracı, her bir konteynerin (veya müzisyenin) yapması gerekeni yaptığından emin olarak adeta bir müzik şefi gibi davranır.

--- a/content/tr/container.md
+++ b/content/tr/container.md
@@ -5,8 +5,6 @@ category: technology
 tags: ["uygulama", "temel kavram", ""]
 ---
 
-## Nedir
-
 Konteyner, bir bilgisayarın işletim sistemi tarafından yönetilen, kaynak ve yetenek kısıtlamalarına sahip, çalışan bir işlemdir.
 Konteyner işlemi içerisinde erişilebilir olan dosyalar konteyner imajı olarak paketlenmiştir.
 Konteynerler aynı makinede birbirlerine bitişik olarak çalışır,

--- a/content/tr/containerization.md
+++ b/content/tr/containerization.md
@@ -5,8 +5,6 @@ category: Teknoloji
 tags: ["uygulama", "", ""]
 ---
 
-## Nedir
-
 Konteynerleştirme, bir uygulamayı ve bağımlılıklarını bir konteyner imajına paketleme sürecidir.
 Konteyner oluşturma süreci, [Open Container Initiative](https://opencontainers.org/) (OCI) standardına uygun olmayı gerektirir.
 Bu standarta uygun bir konteyner imajı üretiliyorsa, hangi konteynerleştirme aracının kullanıldığı önemli değildir.

--- a/content/tr/continuous-delivery.md
+++ b/content/tr/continuous-delivery.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["yöntem", "uygulama", ""]
 ---
 
-## Nedir
-
 Genellikle CD olarak kısaltılan sürekli teslimat (continuous delivery), 
 kod değişikliklerinin otomatik olarak bir kabul ortamına dağıtıldığı (veya sürekli dağıtım (continuous deployment) 
 durumunda üretime otomatik olarak dağıtıldığı) bir dizi uygulamadır. 

--- a/content/tr/continuous-deployment.md
+++ b/content/tr/continuous-deployment.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["uygulama", "yöntem", ""]
 ---
 
-## Nedir
-
 Genellikle CD olarak kısaltılan sürekli dağıtım (continuous deployment), tamamlanmış yazılımı doğrudan üretime dağıtarak [sürekli teslimattan (continuous delivery)](/tr/continuous-delivery/) bir adım daha ileri gider. 
 Sürekli dağıtım (CD), [sürekli entegrasyon (CI)](/tr/continuous-integration/) ile birlikte ele alınır ve genellikle CI/CD olarak adlandırılır. 
 CI süreci, uygulamada yapılan değişikliklerin geçerli olup olmadığını test eder ve CD süreci, kod değişikliklerini bir organizasyonun testten üretime, tüm ortamlarına otomatik olarak dağıtır.

--- a/content/tr/continuous-integration.md
+++ b/content/tr/continuous-integration.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["uygulama", "yöntem", ""]
 ---
 
-## Nedir
-
 Genellikle CI olarak kısaltılan sürekli entegrasyon (continuous integration), kod değişikliklerini mümkün olduğunca düzenli olarak entegre etme uygulamasıdır. 
 CI, [sürekli teslimat (continuous delivery - CD)](/tr/continuous-delivery/) için ilk adımdır. 
 CI süreci, kod değişikliklerinin bir kaynak kontrol sistemine (Git, Mercurial veya Subversion) gönderilmesiyle başlar ve test edilmiş bir yapının CD sistemi tarafından kullanılmaya hazır hale gelmesiyle sona erer.

--- a/content/tr/data-center.md
+++ b/content/tr/data-center.md
@@ -5,8 +5,6 @@ category: Technology
 tags: ["altyapı", "temel kavram", ""]
 ---
 
-## Nedir
-
 Veri merkezi, çoğunlukla sunucular olmak üzere bilgisayarları barındırmak üzere tasarlanmış bina veya tesistir. 
 Veri merkezleri, özellikle [bulut bilişime](/tr/cloud-computing/) odaklandıklarında, yüksek hızlı internet hatlarına bağlanma eğilimindedirler. 
 Veri merkezlerini barındıran binalar, kesintiler sırasında güç sağlayan jeneratörler ve bilgisayarları serin tutan güçlü klimalar dahil olmak üzere olumsuz şartlarda bile hizmeti sürdürecek şekilde donatılmıştır.

--- a/content/tr/distributed-apps.md
+++ b/content/tr/distributed-apps.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["mimari", "", ""]
 ---
 
-## Nedir
-
 Dağıtık uygulama, işlevselliğin birden fazla küçük, bağımsız parçaya bölündüğü bir uygulamadır. 
 Dağıtık uygulamalar genellikle daha büyük bir uygulama içinde farklı sorunları ele alan tekil mikro servislerden oluşur. Cloud native ortamında, tekil bileşenler genellikle bir küme üzerinde konteyner olarak çalışır.
 

--- a/content/tr/distributed-systems.md
+++ b/content/tr/distributed-systems.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["mimari", "", ""]
 ---
 
-## Nedir
-
 Dağıtık sistem, kullanıcılara tek bir sistem olarak görünen, bir ağ üzerinden birbirine bağlanan otonom bilgi işlem ögeleri topluluğudur. 
 Genel olarak düğüm olarak adlandırılan bu bileşenler, donanım cihazları ya da yazılım süreçleri olabilir. 
 Düğümler ortak bir hedefe ulaşmak için programlanır ve birlikte çalışmak için ağ üzerinden bilgi alışverişinde bulunurlar.

--- a/content/tr/event-driven-architecture.md
+++ b/content/tr/event-driven-architecture.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["mimari", "", ""]
 ---
 
-## Nedir
-
 Olaya dayalı mimari, olayların üretilmesini, işlenmesini ve kullanılmasını destekleyen bir yazılım mimarisidir. 
 Olay, bir uygulamanın durumunda meydana gelen herhangi bir değişikliktir. 
 Örneğin, bir araç paylaşım uygulamasında araç çağırmak bir olayı temsil eder. 

--- a/content/tr/infrastructure-as-code.md
+++ b/content/tr/infrastructure-as-code.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["altyapı", "yöntem", ""]
 ---
 
-## Nedir
-
 Kod olarak altyapı _(Infrastructure as Code - IaC)_, altyapı tanımının bir veya daha fazla dosya olarak saklanması uygulamasıdır.
 Bu, servis olarak altyapının _(Infrastructure as a Service - IaaS)_ genellikle
 bir shell script veya diğer yapılandırma araçları aracılığıyla manuel olarak oluşturulduğu geleneksel modelin yerini alır.

--- a/content/tr/kubernetes.md
+++ b/content/tr/kubernetes.md
@@ -5,8 +5,6 @@ category: technology
 tags: ["altyapı", "temel kavram", ""]
 ---
 
-## Nedir
-
 Kubernetes, genellikle K8s olarak kısaltılan, açık kaynaklı bir konteyner orkestratörüdür.
 Modern altyapılarda konteynerleştirilmiş uygulamaların yaşam döngüsünü otomatikleştirir ve bir "veri merkezi işletim sistemi" olarak işlev görerek uygulamaları [dağıtık bir sistem](/tr/distributed-systems/) üzerinde yönetir.
 

--- a/content/tr/microservices-architecture.md
+++ b/content/tr/microservices-architecture.md
@@ -4,8 +4,6 @@ status: Completed
 tags: ["altyapı", "temel kavram", ""]
 ---
 
-## Nedir
-
 Mikroservis mimarisi, uygulamaları birbirinden bağımsız (mikro)servislere ayıran, her bir servisin belirli bir işlevselliğe odaklandığı bir mimari yaklaşımdır.
 Bu servisler birbirleriyle yakın bir şekilde çalışır ve kullanıcıya tek bir sistem gibi görünür.
 Netflix'i bir örnek olarak alalım.

--- a/content/tr/monolithic-apps.md
+++ b/content/tr/monolithic-apps.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["mimari", "temel kavram", ""]
 ---
 
-## Nedir
-
 Monolitik bir uygulama, tüm işlevselliği tek bir dağıtılabilir programda içerir. 
 Bu genellikle bir uygulamayı oluştururken en basit ve en kolay başlangıç noktasıdır. 
 Ancak uygulama büyüyüp karmaşıklaştıkça monolitik uygulamaların bakımı zorlaşabilir. 

--- a/content/tr/nodes.md
+++ b/content/tr/nodes.md
@@ -5,8 +5,6 @@ category: Concept
 tags: ["altyapı", "temel kavram", ""]
 ---
 
-## Nedir
-
 Bir düğüm, ortak bir görevi gerçekleştirmek için diğer bilgisayarlar veya düğümlerle birlikte çalışan bir bilgisayardır.
 Örneğin, dizüstü bilgisayarınız, modeminiz ve yazıcınızı düşünün.
 Hepsi wifi ağınız üzerinden bağlıdır, iletişim kurar ve işbirliği yapar; her biri bir düğümü temsil eder.

--- a/content/tr/pod.md
+++ b/content/tr/pod.md
@@ -4,7 +4,6 @@ status: Completed
 category: concept
 tags: ["altyapı", "temel kavram", ""]
 ---
-## Nedir
 
 [Kubernetes](/tr/kubernetes/) ortamında bir pod, en temel dağıtılabilir birim olarak işlev görür. 
 Konteynerleştirilmiş uygulamaları dağıtmak ve yönetmek için önemli bir yapı taşını temsil eder. 

--- a/content/tr/site-reliability-engineering.md
+++ b/content/tr/site-reliability-engineering.md
@@ -5,8 +5,6 @@ category: concept
 tags: ["yöntem", "", ""]
 ---
 
-## Nedir
-
 Site Güvenilirlik Mühendisliği / Site Reliability Engineering (SRE), operasyon ve yazılım mühendisliğini bir araya getiren bir disiplindir.
 Özetle, yazılım mühendisliğinin altyapı ve operasyon işlerine uygulanmasıdır.
 SRE mühendisleri ürün özellikleri geliştirmek yerine, uygulamaları çalıştırmak için sistemler oluştururlar.


### PR DESCRIPTION
### Describe your changes

The old style guide had 3 subheadings, but the new one has 2. Turkish content has been updated accordingly.

### Checklist before opening this PR (put `x` in the checkboxes)

- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.