### PR TITLE
Remove @matteobisi from Italian L10n approvers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -94,9 +94,6 @@ collaborators:
   - username: ugho16
     permission: push
 
-  - username: matteobisi
-    permission: push
-
   - username: SaraTrap
     permission: push
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,8 +43,8 @@
 /i18n/hi.toml @Garima-Negi @jayesh-srivastava @abhay-raj19 @bishal7679
 
 # Approvers for Italian contents
-/content/it/ @fsbaraglia @ugho16 @matteobisi @SaraTrap @sistella
-/i18n/it.toml @fsbaraglia @ugho16 @matteobisi @SaraTrap @sistella
+/content/it/ @fsbaraglia @ugho16 @SaraTrap @sistella
+/i18n/it.toml @fsbaraglia @ugho16 @SaraTrap @sistella
 
 # Approvers for Japanese contents
 /content/ja/ @inductor @naonishijima @kaitoii11 @yuichi-nakamura @Okabe-Junya


### PR DESCRIPTION
### Describe your changes

Remove @matteobisi from Italian L10n approvers, per [this Slack message](https://cloud-native.slack.com/archives/C02M9HPU9T9/p1762159540893009?thread_ts=1743938902.619549&cid=C02M9HPU9T9).

@matteobisi Thank you for your honest and courageous decision, and for your hard work so far. If you have the time, I hope you'll return as an Italian localization approver.

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
