### PR TITLE
fix(hi): add sign-language section translations to hi.toml

### DIFF
--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -86,3 +86,14 @@ other = "क्या यह पृष्ठ उपयोगी था?"
 other = "हां"
 [feedback_answer_no]
 other = "नहीं"
+
+# Sign language section
+[sign_language_header]
+other = "संकेत भाषा में"
+[sign_language_info]
+other = """
+**नोट**:
+हर देश की अपनी संकेत भाषा होती है; हम,
+[Deaf/Hoh Working Group](https://contribute.cncf.io/accessibility/deaf-and-hard-of-hearing/),
+वैश्विक उपयोग के लिए नए क्लाउड-नेटिव शब्दों के लिए संकेतों को मानकीकृत करने का प्रयास करते हैं।
+"""


### PR DESCRIPTION
### Describe your changes

This PR adds Hindi translations for the **sign-language section** in the `i18n/hi.toml` file to improve localization of the CNCF glossary.

### What has been done

* Added missing Hindi translations for sign-language related tags
* Updated the `i18n/hi.toml` localization file
* Maintained consistency with existing Hindi glossary terminology

### Related Issue

Fixes #3615

### Checklist

* [x] This PR does not contain plagiarism
* [x] The translation follows the glossary localization guidelines
* [x] Only the Hindi localization file (`i18n/hi.toml`) was modified

