### PR TITLE
ci: pin contents: read on the 4 remaining PR checks

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,6 +3,9 @@ name: Links
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-check-links:
     name: CHECK LINKS

--- a/.github/workflows/check-outdated-content.yaml
+++ b/.github/workflows/check-outdated-content.yaml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'content/en/**.md'
 
+permissions:
+  contents: read
+
 jobs:
   check-outdated-content:
     name: Check outdated content

--- a/.github/workflows/es-spellcheck.yml
+++ b/.github/workflows/es-spellcheck.yml
@@ -18,6 +18,9 @@ on:
       - dev-es
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-spanish-spellcheck:
     name: Run PySpelling tool to verify spanish spelling issues

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -13,6 +13,9 @@ on:
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "build"
   build:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` on the four PR-time checks still inheriting org defaults:

- `check-links.yml` — `npm run check:links`.
- `check-outdated-content.yaml` — detects out-of-date Korean/Spanish translations against upstream English content.
- `es-spellcheck.yml` — PySpelling on `content/es/`.
- `spellcheck.yml` — `rojopolis/spellcheck-github-actions` for the English content.

The sibling 4 hardened workflows in this repo already use the same top-level pattern. YAML validated locally.