### PR TITLE
docs: fix invalid LinkedIn URL in French glossary (Ludovic Logiou)

### DIFF
--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -49,7 +49,7 @@ sont des Mainteneurs Émérites, et nous leur sommes profondément reconnaissant
 Enfin, la traduction et localisation française du Glossaire Cloud Native sont réalisées et maintenues par
 [Christophe Sauthier](https://www.linkedin.com/in/christophesauthier/),
 [Flavien Hardy](https://www.linkedin.com/in/flavien-h-93208a18b/),
-[Ludovic Logiou](https://www.linkedin.com/in/ludovic-%F0%9F%92%BB-logiou-98123978/),
+[Ludovic Logiou](https://www.linkedin.com/in/ludovic-logiou-98123978/),
 [Stéphane Este-Gracias](https://www.linkedin.com/in/sestegra/),
 [Guillaume Bernard](https://www.linkedin.com/in/gbernardit/),
 et divers contributeurs.


### PR DESCRIPTION
## Summary

This PR fixes a broken LinkedIn URL for Ludovic Logiou in the French glossary index.

The previous link contained an invalid encoded emoji in the URL, which resulted in a 404 error.

## Changes

- Replaced invalid LinkedIn URL: https://www.linkedin.com/in/ludovic-%F0%9F%92%BB-logiou-98123978/
  
  with correct URL: https://www.linkedin.com/in/ludovic-logiou-98123978/

## Why

The previous link was not accessible (404), preventing proper navigation to the profile.

## Notes

This is a documentation-only fix, no functional code changes.

    
