### PR TITLE
ci: declare workflow-level `contents: read` on spellcheck, check-outdated-content, es-spellcheck

### DIFF
--- a/.github/workflows/check-outdated-content.yaml
+++ b/.github/workflows/check-outdated-content.yaml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'content/en/**.md'
 
+permissions:
+  contents: read
+
 jobs:
   check-outdated-content:
     name: Check outdated content

--- a/.github/workflows/es-spellcheck.yml
+++ b/.github/workflows/es-spellcheck.yml
@@ -18,6 +18,9 @@ on:
       - dev-es
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-spanish-spellcheck:
     name: Run PySpelling tool to verify spanish spelling issues

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -13,6 +13,9 @@ on:
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "build"
   build:


### PR DESCRIPTION
Three lint/check workflows just validate content. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.