### PR TITLE
Localize zh-cn tag labels

### DIFF
--- a/content/zh-cn/shift-left.md
+++ b/content/zh-cn/shift-left.md
@@ -2,7 +2,7 @@
 title: 左移 (Shift Left)
 status: Completed
 category: Concept
-tags: ["methodology", "", ""]
+tags: ["方法论", "", ""]
 ---
 
 ## 是什么

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -20,21 +20,21 @@ other = "里面"
 
 # Phrases for tags
 [ui_see_all_tags]
-other = "See all tags"
+other = "查看所有标签"
 [ui_tag]
-other = "Tag"
+other = "标签"
 [ui_tags]
-other = "Tags"
+other = "标签"
 [ui_search_by_tags]
-other = "Browse by Tags"
+other = "按标签浏览"
 [ui_tags_intro]
-other = "We've categorized the glossary terms. Use the filters to browse terms by tag."
+other = "我们已经将词汇分类。使用筛选器按标签浏览词汇。"
 [ui_or_search_by_tags]
-other = "...or browse by tag"
+other = "...或按标签浏览"
 [ui_select_all]
-other = "Select All"
+other = "全选"
 [ui_deselect_all]
-other = "Deselect All"
+other = "取消全选"
 
 # Footer text
 [footer_all_rights_reserved]


### PR DESCRIPTION
### Related issue number or link

Resolves #2294

### Description

Localizes the Simplified Chinese tag UI strings and replaces the remaining English \methodology\ tag in zh-cn front matter.

### Checklist before opening this PR

- [x] I have signed off my commits.
- [x] I have checked the zh-cn tag strings and front matter tags for remaining English labels.