### PR TITLE
Add Turkish localization for index page contributors

### DIFF
--- a/content/tr/_index.md
+++ b/content/tr/_index.md
@@ -36,6 +36,9 @@ Projenin Türkçe yerelleştirilmesi
  [Oğuzhan Özdemir](https://www.linkedin.com/in/aoguzhanozdemir),
  [Uğur Yılmaz](https://www.linkedin.com/in/uguryilmazdev/),
 [Zehra Karakaya](https://www.linkedin.com/in/zehra-k-7b7a11300/),
+[Onur Canoğlu](https://www.linkedin.com/in/onurcanoglu/),
+[Ayşe Beyaz](https://www.linkedin.com/in/ay%C5%9Fe-beyaz-191b08230/),
+[Mert Şişmanoğlu](https://www.linkedin.com/in/mertssmnoglu/),
 [Muhsin Özbek](https://tr.linkedin.com/in/muhsin-ozbek) ve
 [Yasin Herken](https://www.linkedin.com/in/yasin-herken/) tarafından yürütülmektedir.
 


### PR DESCRIPTION
### Describe your changes

Added 3 contributors (Onur Canoğlu, Ayşe Beyaz, Mert Şişmanoğlu) to the Turkish localization index page contributor list.

### Related issue number or link (ex: `resolves #issue-number`)

N/A

### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.